### PR TITLE
Output code metrics report to STDOUT when octocov command is executed.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,10 @@ var rootCmd = &cobra.Command{
 		if err := c.Load(configPath); err != nil {
 			return err
 		}
+		if !c.Loaded() {
+			cmd.PrintErrf("%s are not found\n", strings.Join(config.DefaultConfigFilePaths, " and "))
+		}
+
 		c.Build()
 
 		if createTable {
@@ -145,10 +149,6 @@ var rootCmd = &cobra.Command{
 
 		if r.CountMeasured() == 0 {
 			return errors.New("nothing could be measured")
-		}
-
-		if !c.Loaded() {
-			return fmt.Errorf("%s are not found", strings.Join(config.DefaultConfigFilePaths, " and "))
 		}
 
 		// Generate coverage report badge

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,6 +151,12 @@ var rootCmd = &cobra.Command{
 			return errors.New("nothing could be measured")
 		}
 
+		cmd.Println("")
+		if err := r.Out(os.Stdout); err != nil {
+			return err
+		}
+		cmd.Println("")
+
 		// Generate coverage report badge
 		if c.CoverageBadgeConfigReady() || coverageBadge {
 			if err := func() error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,37 +153,41 @@ var rootCmd = &cobra.Command{
 
 		// Generate coverage report badge
 		if c.CoverageBadgeConfigReady() || coverageBadge {
-			if !r.IsMeasuredCoverage() {
-				return fmt.Errorf("could not generate badge: %s", "coverage is not measured")
-			}
+			if err := func() error {
+				if !r.IsMeasuredCoverage() {
+					cmd.PrintErrf("Skip generating badge: %s\n", "coverage is not measured")
+					return nil
+				}
+				var out *os.File
+				cp := r.CoveragePercent()
+				if c.Coverage.Badge.Path == "" {
+					out = os.Stdout
+				} else {
+					cmd.PrintErrln("Generate coverage report badge...")
+					err := os.MkdirAll(filepath.Dir(c.Coverage.Badge.Path), 0755) // #nosec
+					if err != nil {
+						return err
+					}
+					bp, err := filepath.Abs(filepath.Clean(c.Coverage.Badge.Path))
+					if err != nil {
+						return err
+					}
+					out, err = os.OpenFile(bp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // #nosec
+					if err != nil {
+						return err
+					}
+					addPaths = append(addPaths, bp)
+				}
 
-			var out *os.File
-			cp := r.CoveragePercent()
-			if c.Coverage.Badge.Path == "" {
-				out = os.Stdout
-			} else {
-				cmd.PrintErrln("Generate coverage report badge...")
-				err := os.MkdirAll(filepath.Dir(c.Coverage.Badge.Path), 0755) // #nosec
-				if err != nil {
+				b := badge.New("coverage", fmt.Sprintf("%.1f%%", cp))
+				b.MessageColor = c.CoverageColor(cp)
+				if err := b.Render(out); err != nil {
 					return err
 				}
-				bp, err := filepath.Abs(filepath.Clean(c.Coverage.Badge.Path))
-				if err != nil {
-					return err
-				}
-				out, err = os.OpenFile(bp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // #nosec
-				if err != nil {
-					return err
-				}
-				addPaths = append(addPaths, bp)
-			}
-
-			b := badge.New("coverage", fmt.Sprintf("%.1f%%", cp))
-			b.MessageColor = c.CoverageColor(cp)
-			if err := b.Render(out); err != nil {
+				return nil
+			}(); err != nil {
 				return err
 			}
-
 			if coverageBadge {
 				return nil
 			}
@@ -191,34 +195,40 @@ var rootCmd = &cobra.Command{
 
 		// Generate code-to-test-ratio report badge
 		if c.CodeToTestRatioBadgeConfigReady() || ratioBadge {
-			if !r.IsMeasuredCodeToTestRatio() {
-				return fmt.Errorf("could not generate badge: %s", "code-to-test-ratio is not measured")
-			}
+			if err := func() error {
+				if !r.IsMeasuredCodeToTestRatio() {
+					cmd.PrintErrf("Skip generating badge: %s\n", "coverage is not measured")
+					return nil
+				}
 
-			var out *os.File
-			tr := r.CodeToTestRatioRatio()
-			if c.CodeToTestRatio.Badge.Path == "" {
-				out = os.Stdout
-			} else {
-				cmd.PrintErrln("Generate code-to-test-ratio report badge...")
-				err := os.MkdirAll(filepath.Dir(c.CodeToTestRatio.Badge.Path), 0755) // #nosec
-				if err != nil {
-					return err
+				var out *os.File
+				tr := r.CodeToTestRatioRatio()
+				if c.CodeToTestRatio.Badge.Path == "" {
+					out = os.Stdout
+				} else {
+					cmd.PrintErrln("Generate code-to-test-ratio report badge...")
+					err := os.MkdirAll(filepath.Dir(c.CodeToTestRatio.Badge.Path), 0755) // #nosec
+					if err != nil {
+						return err
+					}
+					bp, err := filepath.Abs(filepath.Clean(c.CodeToTestRatio.Badge.Path))
+					if err != nil {
+						return err
+					}
+					out, err = os.OpenFile(bp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // #nosec
+					if err != nil {
+						return err
+					}
+					addPaths = append(addPaths, bp)
 				}
-				bp, err := filepath.Abs(filepath.Clean(c.CodeToTestRatio.Badge.Path))
-				if err != nil {
-					return err
-				}
-				out, err = os.OpenFile(bp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // #nosec
-				if err != nil {
-					return err
-				}
-				addPaths = append(addPaths, bp)
-			}
 
-			b := badge.New("code to test ratio", fmt.Sprintf("1:%.1f", tr))
-			b.MessageColor = c.CodeToTestRatioColor(tr)
-			if err := b.Render(out); err != nil {
+				b := badge.New("code to test ratio", fmt.Sprintf("1:%.1f", tr))
+				b.MessageColor = c.CodeToTestRatioColor(tr)
+				if err := b.Render(out); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
 				return err
 			}
 
@@ -229,36 +239,43 @@ var rootCmd = &cobra.Command{
 
 		// Generate test-execution-time report badge
 		if c.TestExecutionTimeBadgeConfigReady() || timeBadge {
-			if !r.IsMeasuredTestExecutionTime() {
-				return fmt.Errorf("could not generate badge: %s", "test-execution-time is not measured")
-			}
+			if err := func() error {
+				if !r.IsMeasuredTestExecutionTime() {
+					cmd.PrintErrf("Skip generating badge: %s\n", "test-execution-time is not measured")
+					return nil
+				}
 
-			var out *os.File
-			if c.TestExecutionTime.Badge.Path == "" {
-				out = os.Stdout
-			} else {
-				cmd.PrintErrln("Generate test-execution-time report badge...")
-				err := os.MkdirAll(filepath.Dir(c.TestExecutionTime.Badge.Path), 0755) // #nosec
-				if err != nil {
-					return err
+				var out *os.File
+				if c.TestExecutionTime.Badge.Path == "" {
+					out = os.Stdout
+				} else {
+					cmd.PrintErrln("Generate test-execution-time report badge...")
+					err := os.MkdirAll(filepath.Dir(c.TestExecutionTime.Badge.Path), 0755) // #nosec
+					if err != nil {
+						return err
+					}
+					bp, err := filepath.Abs(filepath.Clean(c.TestExecutionTime.Badge.Path))
+					if err != nil {
+						return err
+					}
+					out, err = os.OpenFile(bp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // #nosec
+					if err != nil {
+						return err
+					}
+					addPaths = append(addPaths, bp)
 				}
-				bp, err := filepath.Abs(filepath.Clean(c.TestExecutionTime.Badge.Path))
-				if err != nil {
-					return err
-				}
-				out, err = os.OpenFile(bp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // #nosec
-				if err != nil {
-					return err
-				}
-				addPaths = append(addPaths, bp)
-			}
 
-			d := time.Duration(*r.TestExecutionTime)
-			b := badge.New("test execution time", d.String())
-			b.MessageColor = c.TestExecutionTimeColor(d)
-			if err := b.Render(out); err != nil {
+				d := time.Duration(*r.TestExecutionTime)
+				b := badge.New("test execution time", d.String())
+				b.MessageColor = c.TestExecutionTimeColor(d)
+				if err := b.Render(out); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
 				return err
 			}
+
 			if timeBadge {
 				return nil
 			}
@@ -266,7 +283,7 @@ var rootCmd = &cobra.Command{
 
 		// Store report
 		if c.ReportConfigReady() {
-			cmd.PrintErrln("Store report...")
+			cmd.PrintErrln("Storing report...")
 			if err := c.BuildReportConfig(); err != nil {
 				return err
 			}
@@ -292,7 +309,7 @@ var rootCmd = &cobra.Command{
 
 		// Comment report to pull request
 		if c.CommentConfigReady() {
-			cmd.PrintErrln("Comment report...")
+			cmd.PrintErrln("Commenting report...")
 			if err := commentReport(ctx, c, r); err != nil {
 				cmd.PrintErrf("Skip commenting the report to pull request: %v\n", err)
 			}

--- a/pkg/coverage/coverage_test.go
+++ b/pkg/coverage/coverage_test.go
@@ -78,7 +78,7 @@ func TestCompare(t *testing.T) {
 		opts := []cmp.Option{
 			cmpopts.IgnoreUnexported(DiffCoverage{}),
 			cmpopts.IgnoreFields(DiffCoverage{}, "CoverageA", "CoverageB"),
-			cmpopts.SortSlices(func(i, j DiffFileCoverage) bool {
+			cmpopts.SortSlices(func(i, j *DiffFileCoverage) bool {
 				return i.File < j.File
 			}),
 			cmpopts.IgnoreFields(DiffFileCoverage{}, "FileCoverageA", "FileCoverageB"),

--- a/report/report.go
+++ b/report/report.go
@@ -129,6 +129,33 @@ func (r *Report) Table() string {
 	return strings.Replace(buf.String(), "---|", "--:|", len(h))
 }
 
+func (r *Report) Out(w io.Writer) error {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader([]string{"", makeHeadTitle(r.Ref, r.Commit, r.rp)})
+	table.SetAutoFormatHeaders(false)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("-")
+	table.SetHeaderLine(true)
+	table.SetBorder(false)
+	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT})
+
+	if r.Coverage != nil {
+		table.Rich([]string{"Coverage", fmt.Sprintf("%.1f%%", r.CoveragePercent())}, []tablewriter.Colors{tablewriter.Colors{tablewriter.Bold}, tablewriter.Colors{}})
+	}
+
+	if r.CodeToTestRatio != nil {
+		table.Rich([]string{"Code to Test Ratio", fmt.Sprintf("1:%.1f", r.CodeToTestRatioRatio())}, []tablewriter.Colors{tablewriter.Colors{tablewriter.Bold}, tablewriter.Colors{}})
+	}
+
+	if r.TestExecutionTime != nil {
+		table.Rich([]string{"Test Execution Time", time.Duration(*r.TestExecutionTime).String()}, []tablewriter.Colors{tablewriter.Colors{tablewriter.Bold}, tablewriter.Colors{}})
+	}
+
+	table.Render()
+	return nil
+}
+
 func (r *Report) FileCoveagesTable(files []*gh.PullRequestFile) string {
 	if r.Coverage == nil {
 		return ""


### PR DESCRIPTION
```console
$ octocov
octocov version dev
Skip measuring test execution time: env GITHUB_REPOSITORY is not set

                      out-report (7b042d1)
--------------------------------------------
  Coverage                           67.6%
  Code to Test Ratio                 1:0.3

Generate coverage report badge...
Generate code-to-test-ratio report badge...
Skip generating badge: test-execution-time is not measured
Commenting report...
Skip commenting the report to pull request: could not get owner and repo
Skip pushing badges: env GITHUB_EVENT_NAME is not set.
```