### PR TITLE
Fix markdown table when long branch name

### DIFF
--- a/report/diff_report.go
+++ b/report/diff_report.go
@@ -41,6 +41,7 @@ type DiffTestExecutionTime struct {
 func (d *DiffReport) Out(w io.Writer) {
 	table := tablewriter.NewWriter(w)
 	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")
 	table.SetRowSeparator("-")
@@ -64,6 +65,7 @@ func (d *DiffReport) Table() string {
 	buf := new(bytes.Buffer)
 	table := tablewriter.NewWriter(buf)
 	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetCenterSeparator("|")
 	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT})
@@ -294,6 +296,7 @@ func (d *DiffReport) FileCoveagesTable(files []*gh.PullRequestFile) string {
 	h := []string{"Files", "Coverage", "+/-"}
 	table.SetHeader(h)
 	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetCenterSeparator("|")
 	for _, v := range rows {

--- a/report/report.go
+++ b/report/report.go
@@ -98,6 +98,7 @@ func (r *Report) Table() string {
 	table := tablewriter.NewWriter(buf)
 	table.SetHeader(h)
 	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetCenterSeparator("|")
 	table.Append(m)
@@ -109,6 +110,7 @@ func (r *Report) Out(w io.Writer) error {
 	table := tablewriter.NewWriter(w)
 	table.SetHeader([]string{"", makeHeadTitle(r.Ref, r.Commit, r.rp)})
 	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")
 	table.SetRowSeparator("-")
@@ -181,6 +183,7 @@ func (r *Report) FileCoveagesTable(files []*gh.PullRequestFile) string {
 	h := []string{"Files", "Coverage"}
 	table.SetHeader(h)
 	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetCenterSeparator("|")
 	for _, v := range rows {


### PR DESCRIPTION
### before

![image](https://user-images.githubusercontent.com/57114/136927816-68a48ed4-5fd1-421f-89c8-68c97b28a79f.png)

### after

![image](https://user-images.githubusercontent.com/57114/136928603-c60a103e-dd8e-4c4e-b47a-228a0b3e6d09.png)
