### PR TITLE
Fix Cloud Storage (gcs) client creation using default application credentials

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -78,7 +78,7 @@ func New(ctx context.Context, u, configRoot string) (Datastore, error) {
 		if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON") != "" {
 			client, err = storage.NewClient(ctx, option.WithCredentialsJSON([]byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON"))))
 		} else {
-			client, err = storage.NewClient(ctx, nil)
+			client, err = storage.NewClient(ctx)
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
I got the following error using `gcs` datastore for `report` and `diff` (without `GOOGLE_APPLICATION_CREDENTIALS_JSON` because I'd like to use default application credentials):

``` console
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xd80510]

goroutine 1 [running]:
google.golang.org/api/transport/http.newSettings(0xc0021a2600, 0x5, 0x8, 0xc0021a2600, 0xc00207d700, 0x40)
	/Users/k1low/go/pkg/mod/google.golang.org/api@v0.52.0/transport/http/dial.go:105 +0x70
google.golang.org/api/transport/http.NewClient(0x197edc8, 0xc0001a4020, 0xc0021a2600, 0x5, 0x8, 0xc0021a2600, 0x4, 0x8, 0xc0011c2680, 0xc00210f800)
	/Users/k1low/go/pkg/mod/google.golang.org/api@v0.52.0/transport/http/dial.go:32 +0x4c
cloud.google.com/go/storage.NewClient(0x197edc8, 0xc0001a4020, 0xc00207d700, 0x4, 0x4, 0x2, 0xc0020e7800, 0x2)
	/Users/k1low/go/pkg/mod/cloud.google.com/go/storage@v1.16.0/storage.go:136 +0x253
github.com/k1LoW/octocov/datastore.New(0x197edc8, 0xc0001a4020, 0xc0001e00c0, 0x29, 0xc000314c40, 0x11, 0x19, 0x0, 0x40dedb, 0xc0021cad60)
	/Users/k1low/src/github.com/k1LoW/octocov/datastore/datastore.go:81 +0x665
github.com/k1LoW/octocov/cmd.glob..func4.4(0x26d1700, 0xc0003b9d80, 0x197edc8, 0xc0001a4020, 0xc001105570, 0x0, 0x0)
	/Users/k1low/src/github.com/k1LoW/octocov/cmd/root.go:315 +0x3a5
github.com/k1LoW/octocov/cmd.glob..func4(0x26d1700, 0x27f01a0, 0x0, 0x0, 0x0, 0x0)
	/Users/k1low/src/github.com/k1LoW/octocov/cmd/root.go:356 +0xfa5
github.com/spf13/cobra.(*Command).execute(0x26d1700, 0xc0001981d0, 0x0, 0x0, 0x26d1700, 0xc0001981d0)
	/Users/k1low/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x26d1700, 0x5, 0x0, 0x0)
	/Users/k1low/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/k1low/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
github.com/k1LoW/octocov/cmd.Execute()
	/Users/k1low/src/github.com/k1LoW/octocov/cmd/root.go:430 +0xc7
main.main()
	/Users/k1low/src/github.com/k1LoW/octocov/main.go:48 +0x12e
```

This pull request should fix the error.
