### PR TITLE
fix(error): improve execution time violation message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ octocov
 .DS_Store
 /.tmp/
 /*.cast
+.idea

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ testExecutionTime:
 
 ``` console
 $ octocov
-Error: test execution time is 1m15s, which is below the accepted 1m
+Error: test execution time is 1m15s, which is above the accepted 1m
 ```
 
 ### Generate report badges self.

--- a/config/config.go
+++ b/config/config.go
@@ -184,7 +184,7 @@ func (c *Config) Acceptable(r *report.Report) error {
 			return err
 		}
 		if *r.TestExecutionTime > float64(a) {
-			return fmt.Errorf("test execution time is %v, which is below the accepted %v", time.Duration(*r.TestExecutionTime), a)
+			return fmt.Errorf("test execution time is %v, which is above the accepted %v", time.Duration(*r.TestExecutionTime), a)
 		}
 	}
 


### PR DESCRIPTION
It should be 'above' instead of 'below'.

_**Original**_
Error: test execution time is 1m15s, which is below the accepted 1m

_**Updated**_
Error: test execution time is 1m15s, which is above the accepted 1m