### PR TITLE
Update `acceptable` section logic

### DIFF
--- a/central/central.go
+++ b/central/central.go
@@ -164,7 +164,7 @@ func (c *Central) generateBadges() ([]string, error) {
 
 		// Test Execution Time
 		if r.TestExecutionTime != nil {
-			d := time.Duration(*r.TestExecutionTime)
+			d := time.Duration(r.TestExecutionTimeNano())
 			bp := filepath.Join(r.Repository, "time.svg")
 			out := new(bytes.Buffer)
 			b := badge.New("test execution time", d.String())
@@ -269,7 +269,7 @@ func funcs() map[string]interface{} {
 			if r.TestExecutionTime == nil {
 				return "-"
 			}
-			return time.Duration(*r.TestExecutionTime).String()
+			return time.Duration(r.TestExecutionTimeNano()).String()
 		},
 	}
 }

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -9,7 +9,7 @@ import (
 	"github.com/k1LoW/octocov/report"
 )
 
-func commentReport(ctx context.Context, c *config.Config, r, rOrig *report.Report) error {
+func commentReport(ctx context.Context, c *config.Config, r, rPrev *report.Report) error {
 	repo, err := gh.Parse(c.Repository)
 	if err != nil {
 		return err
@@ -31,8 +31,8 @@ func commentReport(ctx context.Context, c *config.Config, r, rOrig *report.Repor
 		footer = "Reported by octocov"
 	}
 	var table, fileTable string
-	if rOrig != nil {
-		d := rOrig.Compare(r)
+	if rPrev != nil {
+		d := rPrev.Compare(r)
 		table = d.Table()
 		fileTable = d.FileCoveagesTable(files)
 	} else {

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -70,10 +70,11 @@ var viewCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				defer func() {
-					_ = fp.Close()
-				}()
 				if err := coverage.NewPrinter(fc).Print(fp, os.Stdout); err != nil {
+					_ = fp.Close()
+					return err
+				}
+				if err := fp.Close(); err != nil {
 					return err
 				}
 				return nil

--- a/config/config.go
+++ b/config/config.go
@@ -210,13 +210,14 @@ var (
 	compOpRe      = regexp.MustCompile(`^\s*[><=].+$`)
 
 	trimRatioPrefixRe = regexp.MustCompile(`1:([\d.]+)`)
-	durationRe        = regexp.MustCompile(`[\d.]+\s*[a-z]+`)
+	durationRe        = regexp.MustCompile(`[\d][\d\.\sa-z]*[a-z]`)
 )
 
 func coverageAcceptable(current, prev float64, cond string) error {
 	if cond == "" {
 		return nil
 	}
+	org := cond
 	// Trim '%'
 	cond = trimPercentRe.ReplaceAllString(cond, "$1")
 
@@ -237,7 +238,7 @@ func coverageAcceptable(current, prev float64, cond string) error {
 	}
 
 	if !ok.(bool) {
-		return fmt.Errorf("code coverage is %.1f%%. the condition in the `acceptable` section is not met (%s)", current, cond)
+		return fmt.Errorf("code coverage is %.1f%%. the condition in the `acceptable` section is not met (%s)", current, org)
 	}
 	return nil
 }
@@ -246,6 +247,7 @@ func codeToTestRatioAcceptable(current, prev float64, cond string) error {
 	if cond == "" {
 		return nil
 	}
+	org := cond
 	// Trim '1:'
 	cond = trimRatioPrefixRe.ReplaceAllString(cond, "$1")
 
@@ -266,7 +268,7 @@ func codeToTestRatioAcceptable(current, prev float64, cond string) error {
 	}
 
 	if !ok.(bool) {
-		return fmt.Errorf("code to test ratio is 1:%.1f. the condition in the `acceptable` section is not met (%s)", current, cond)
+		return fmt.Errorf("code to test ratio is 1:%.1f. the condition in the `acceptable` section is not met (%s)", current, org)
 	}
 	return nil
 }
@@ -275,6 +277,7 @@ func testExecutionTimeAcceptable(current, prev float64, cond string) error {
 	if cond == "" {
 		return nil
 	}
+	org := cond
 	matches := durationRe.FindAllString(cond, -1)
 	for _, m := range matches {
 		d, err := duration.Parse(m)
@@ -301,7 +304,7 @@ func testExecutionTimeAcceptable(current, prev float64, cond string) error {
 	}
 
 	if !ok.(bool) {
-		return fmt.Errorf("test execution time is %v. the condition in the `acceptable` section is not met (%s)", time.Duration(current), cond)
+		return fmt.Errorf("test execution time is %v. the condition in the `acceptable` section is not met (%s)", time.Duration(current), org)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -199,7 +199,7 @@ var (
 	compOpRe      = regexp.MustCompile(`^\s*[><=].+$`)
 
 	trimRatioPrefixRe = regexp.MustCompile(`1:([\d.]+)`)
-	durationRe        = regexp.MustCompile(`[\d.]+[a-z]+`)
+	durationRe        = regexp.MustCompile(`[\d.]+\s*[a-z]+`)
 )
 
 func coverageAcceptable(current, prev float64, cond string) error {

--- a/config/config.go
+++ b/config/config.go
@@ -169,23 +169,34 @@ func (c *Config) Loaded() bool {
 
 func (c *Config) Acceptable(r, rPrev *report.Report) error {
 	if err := c.CoverageConfigReady(); err == nil {
-		if err := coverageAcceptable(r.CoveragePercent(), rPrev.CoveragePercent(), c.Coverage.Acceptable); err != nil {
+		prev := 0.0
+		if rPrev != nil {
+			prev = rPrev.CoveragePercent()
+		}
+		if err := coverageAcceptable(r.CoveragePercent(), prev, c.Coverage.Acceptable); err != nil {
 			return err
 		}
 	}
 
 	if err := c.CodeToTestRatioConfigReady(); err == nil {
-		if err := codeToTestRatioAcceptable(r.CodeToTestRatioRatio(), rPrev.CodeToTestRatioRatio(), c.CodeToTestRatio.Acceptable); err != nil {
+		prev := 0.0
+		if rPrev != nil {
+			prev = rPrev.CodeToTestRatioRatio()
+		}
+		if err := codeToTestRatioAcceptable(r.CodeToTestRatioRatio(), prev, c.CodeToTestRatio.Acceptable); err != nil {
 			return err
 		}
 	}
 
 	if err := c.TestExecutionTimeConfigReady(); err == nil {
-		tPrev := rPrev.TestExecutionTimeNano()
-		if !rPrev.IsMeasuredTestExecutionTime() {
-			tPrev = largeEnoughTime
+		prev := largeEnoughTime
+		if rPrev != nil {
+			if rPrev.IsMeasuredTestExecutionTime() {
+				prev = rPrev.TestExecutionTimeNano()
+			}
 		}
-		if err := testExecutionTimeAcceptable(r.TestExecutionTimeNano(), tPrev, c.TestExecutionTime.Acceptable); err != nil {
+
+		if err := testExecutionTimeAcceptable(r.TestExecutionTimeNano(), prev, c.TestExecutionTime.Acceptable); err != nil {
 			return err
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,6 +69,14 @@ func TestCoverageAcceptable(t *testing.T) {
 		{"50%", 50.0, false},
 		{"49.9%", 50.0, false},
 		{"49.9", 50.0, false},
+		{">= 60%", 50.0, true},
+		{">= 50%", 50.0, false},
+		{">= 49.9%", 50.0, false},
+		{">= 49.9", 50.0, false},
+		{">=60%", 50.0, true},
+		{">=50%", 50.0, false},
+		{">=49.9%", 50.0, false},
+		{">=49.9", 50.0, false},
 	}
 	for _, tt := range tests {
 		if err := coverageAcceptable(tt.cov, tt.cond); err != nil {
@@ -93,6 +101,14 @@ func TestCodeToTestRatioAcceptable(t *testing.T) {
 		{"1:1.1", 1.0, true},
 		{"1", 1.0, false},
 		{"1.1", 1.0, true},
+		{">= 1:1", 1.0, false},
+		{">= 1:1.1", 1.0, true},
+		{">= 1", 1.0, false},
+		{">= 1.1", 1.0, true},
+		{">=1:1", 1.0, false},
+		{">=1:1.1", 1.0, true},
+		{">=1", 1.0, false},
+		{">=1.1", 1.0, true},
 	}
 	for _, tt := range tests {
 		if err := codeToTestRatioAcceptable(tt.ratio, tt.cond); err != nil {
@@ -116,6 +132,12 @@ func TestTestExecutionTimeAcceptable(t *testing.T) {
 		{"1min", float64(time.Minute), false},
 		{"59s", float64(time.Minute), true},
 		{"61sec", float64(time.Minute), false},
+		{"<= 1min", float64(time.Minute), false},
+		{"<= 59s", float64(time.Minute), true},
+		{"<= 61sec", float64(time.Minute), false},
+		{"<=1min", float64(time.Minute), false},
+		{"<=59s", float64(time.Minute), true},
+		{"<=61sec", float64(time.Minute), false},
 	}
 	for _, tt := range tests {
 		if err := testExecutionTimeAcceptable(tt.ti, tt.cond); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -79,11 +79,12 @@ func TestCoverageAcceptable(t *testing.T) {
 		c.Build()
 
 		r := &report.Report{}
+		rPrev := &report.Report{}
 		r.Coverage = &coverage.Coverage{
 			Covered: 50,
 			Total:   100,
 		}
-		if err := c.Acceptable(r); err != nil {
+		if err := c.Acceptable(r, rPrev); err != nil {
 			if !tt.wantErr {
 				t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
 			}
@@ -113,11 +114,12 @@ func TestCodeToTestRatioAcceptable(t *testing.T) {
 		}
 		c.Build()
 		r := &report.Report{}
+		rPrev := &report.Report{}
 		r.CodeToTestRatio = &ratio.Ratio{
 			Code: 100,
 			Test: 100,
 		}
-		if err := c.Acceptable(r); err != nil {
+		if err := c.Acceptable(r, rPrev); err != nil {
 			if !tt.wantErr {
 				t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
 			}
@@ -145,9 +147,10 @@ func TestTestExecutionTimeAcceptable(t *testing.T) {
 		}
 		c.Build()
 		r := &report.Report{}
+		rPrev := &report.Report{}
 		e := float64(time.Minute)
 		r.TestExecutionTime = &e
-		if err := c.Acceptable(r); err != nil {
+		if err := c.Acceptable(r, rPrev); err != nil {
 			if !tt.wantErr {
 				t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -155,6 +155,11 @@ func TestTestExecutionTimeAcceptable(t *testing.T) {
 		{"59 s", float64(time.Minute), 0, true},
 		{"61 sec", float64(time.Minute), 0, false},
 
+		{"1min1sec", float64(time.Minute), 0, false},
+		{"<=1min1sec", float64(time.Minute), 0, false},
+		{"<= 1 min 1 sec", float64(time.Minute), 0, false},
+		{"current <= 1 min 1 sec", float64(time.Minute), 0, false},
+
 		{"current <= 1min", float64(time.Minute), float64(59 * time.Second), false},
 		{"current > prev", float64(time.Minute), float64(59 * time.Second), false},
 		{"diff <= 1sec", float64(time.Minute), float64(59 * time.Second), false},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -151,6 +151,9 @@ func TestTestExecutionTimeAcceptable(t *testing.T) {
 		{"<=1min", float64(time.Minute), 0, false},
 		{"<=59s", float64(time.Minute), 0, true},
 		{"<=61sec", float64(time.Minute), 0, false},
+		{"1 min", float64(time.Minute), 0, false},
+		{"59 s", float64(time.Minute), 0, true},
+		{"61 sec", float64(time.Minute), 0, false},
 
 		{"current <= 1min", float64(time.Minute), float64(59 * time.Second), false},
 		{"current > prev", float64(time.Minute), float64(59 * time.Second), false},

--- a/datastore/bq/bq.go
+++ b/datastore/bq/bq.go
@@ -102,7 +102,7 @@ func (b *BQ) StoreReport(ctx context.Context, r *report.Report) error {
 	}
 	if r.TestExecutionTime != nil {
 		rr.TestExecutionTime = bigquery.NullFloat64{
-			Float64: *r.TestExecutionTime,
+			Float64: r.TestExecutionTimeNano(),
 			Valid:   true,
 		}
 	}

--- a/pkg/badge/badge.go
+++ b/pkg/badge/badge.go
@@ -12,6 +12,7 @@ import (
 	_ "image/png"
 	"io"
 	"os"
+	"path/filepath"
 	"text/template"
 
 	"github.com/antchfx/xmlquery"
@@ -69,7 +70,7 @@ func (b *Badge) AddIcon(imgf []byte) error {
 }
 
 func (b *Badge) AddIconFile(f string) error {
-	imgf, err := os.ReadFile(f)
+	imgf, err := os.ReadFile(filepath.Clean(f))
 	if err != nil {
 		return err
 	}

--- a/pkg/coverage/lcov.go
+++ b/pkg/coverage/lcov.go
@@ -33,9 +33,6 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	defer func() {
-		_ = r.Close()
-	}()
 	scanner := bufio.NewScanner(r)
 	var (
 		fileName       string
@@ -76,14 +73,17 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 			total += 1
 			nums := strings.Split(splitted[1], ",")
 			if len(nums) != 2 {
+				_ = r.Close()
 				return nil, "", fmt.Errorf("can not parse: %s", l)
 			}
 			line, err := strconv.Atoi(nums[0])
 			if err != nil {
+				_ = r.Close()
 				return nil, "", err
 			}
 			count, err := strconv.Atoi(nums[1])
 			if err != nil {
+				_ = r.Close()
 				return nil, "", err
 			}
 			if count > 0 {
@@ -98,6 +98,9 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 		default:
 			// not implemented
 		}
+	}
+	if err := r.Close(); err != nil {
+		return nil, "", err
 	}
 	if !parsed {
 		return nil, "", errors.New("can not parse")

--- a/pkg/ratio/copy_from_gocloc.go
+++ b/pkg/ratio/copy_from_gocloc.go
@@ -105,19 +105,19 @@ func getFileTypeByShebang(path string) (shebangLang string, ok bool) {
 	if err != nil {
 		return // ignore error
 	}
-	defer func() {
-		_ = f.Close()
-	}()
-
 	reader := bufio.NewReader(f)
 	line, err := reader.ReadBytes('\n')
 	if err != nil {
+		_ = f.Close()
 		return
 	}
 	line = bytes.TrimLeftFunc(line, unicode.IsSpace)
 
 	if len(line) > 2 && line[0] == '#' && line[1] == '!' {
+		_ = f.Close()
 		return getShebang(string(line))
 	}
+	_ = f.Close()
+
 	return
 }

--- a/report/report.go
+++ b/report/report.go
@@ -88,7 +88,7 @@ func (r *Report) Table() string {
 	}
 	if r.TestExecutionTime != nil {
 		h = append(h, "Test Execution Time")
-		d := time.Duration(*r.TestExecutionTime)
+		d := time.Duration(r.TestExecutionTimeNano())
 		m = append(m, d.String())
 	}
 	buf := new(bytes.Buffer)
@@ -309,6 +309,13 @@ func (r *Report) CodeToTestRatioRatio() float64 {
 	return float64(r.CodeToTestRatio.Test) / float64(r.CodeToTestRatio.Code)
 }
 
+func (r *Report) TestExecutionTimeNano() float64 {
+	if r.TestExecutionTime == nil {
+		return 0.0
+	}
+	return *r.TestExecutionTime
+}
+
 func (r *Report) Validate() error {
 	if r.Repository == "" {
 		return fmt.Errorf("coverage report '%s' (env %s) is not set", "repository", "GITHUB_REPOSITORY")
@@ -347,9 +354,9 @@ func (r *Report) Compare(r2 *Report) *DiffReport {
 			TestExecutionTimeB: r2.TestExecutionTime,
 		}
 		var t1, t2 float64
-		t1 = *r.TestExecutionTime
+		t1 = r.TestExecutionTimeNano()
 		if r2.TestExecutionTime != nil {
-			t2 = *r2.TestExecutionTime
+			t2 = r2.TestExecutionTimeNano()
 		}
 		dt.Diff = t2 - t1
 		d.TestExecutionTime = dt


### PR DESCRIPTION
`acceptable:` section can now be used to write conditions.

The variables that can be used are as follows.

| value | description |
| --- | --- |
| `current` | Current code metrics value |
| `prev` | Previous value. This value is taken from `diff.datastores:`. |
| `diff` | The result of `current - prev` |

You can also omit the expression as follows ( code coverage example )

| Omitted expression | Expanded expression |
| --- | --- |
| `60%` | `current >= 60%` |
| `> 60%` | `current > 60%` |