### PR TITLE
[BREAKING] Support multiple coverage report files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Add `.octocov.yml` ( or `octocov.yml` ) file to your repository.
 ``` yaml
 # .octocov.yml
 coverage:
-  path: coverage.out
+  paths:
+    - coverage.out
 codeToTestRatio:
   code:
     - '**/*.go'
@@ -310,13 +311,18 @@ Configuration for code coverage.
 
 ### `coverage.path:`
 
+`coverage.path:` has been deprecated. Please use `coverage.paths:` instead.
+
+### `coverage.paths:`
+
 The path to the coverage report file.
 
 If no path is specified, the default path for each coverage format will be scanned.
 
 ``` yaml
 coverage:
-  path: tests/coverage.xml
+  paths:
+    - tests/coverage.xml
 ```
 
 ### `coverage.acceptable:`
@@ -937,7 +943,8 @@ If you want to specify the path of the report file, set `coverage.path`
 
 ``` yaml
 coverage:
-  path: /path/to/coverage.txt
+  paths:
+    - /path/to/coverage.txt
 ```
 
 ### Go coverage

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -37,7 +37,7 @@ var diffCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		a := &report.Report{}
-		if err := a.MeasureCoverage(args[0]); err != nil {
+		if err := a.Load(args[0]); err != nil {
 			return err
 		}
 		if a.Timestamp.IsZero() {
@@ -49,7 +49,7 @@ var diffCmd = &cobra.Command{
 		}
 
 		b := &report.Report{}
-		if err := b.MeasureCoverage(args[1]); err != nil {
+		if err := b.Load(args[1]); err != nil {
 			return err
 		}
 		if b.Timestamp.IsZero() {

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -54,11 +54,11 @@ var dumpCmd = &cobra.Command{
 		if err := c.CoverageConfigReady(); err != nil {
 			cmd.PrintErrf("Skip measuring code coverage: %v\n", err)
 		} else {
-			path := c.Coverage.Path
+			paths := c.Coverage.Paths
 			if reportPath != "" {
-				path = reportPath
+				paths = append(paths, reportPath)
 			}
-			if err := r.MeasureCoverage(path); err != nil {
+			if err := r.MeasureCoverage(paths); err != nil {
 				cmd.PrintErrf("Skip measuring code coverage: %v\n", err)
 			}
 		}

--- a/cmd/lsFiles.go
+++ b/cmd/lsFiles.go
@@ -55,11 +55,11 @@ var lsFilesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		path := c.Coverage.Path
+		paths := c.Coverage.Paths
 		if reportPath != "" {
-			path = reportPath
+			paths = append(paths, reportPath)
 		}
-		if err := r.MeasureCoverage(path); err != nil {
+		if err := r.MeasureCoverage(paths); err != nil {
 			return err
 		}
 		t := 0

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,8 +135,7 @@ var rootCmd = &cobra.Command{
 		if err := c.CoverageConfigReady(); err != nil {
 			cmd.PrintErrf("Skip measuring code coverage: %v\n", err)
 		} else {
-			path := c.Coverage.Path
-			if err := r.MeasureCoverage(path); err != nil {
+			if err := r.MeasureCoverage(c.Coverage.Paths); err != nil {
 				cmd.PrintErrf("Skip measuring code coverage: %v\n", err)
 			}
 		}
@@ -349,7 +348,7 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				if err := rt.MeasureCoverage(c.Diff.Path); err == nil {
+				if err := rt.MeasureCoverage([]string{c.Diff.Path}); err == nil {
 					if rPrev == nil || rPrev.Timestamp.UnixNano() < rt.Timestamp.UnixNano() {
 						rPrev = rt
 					}

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -53,11 +53,11 @@ var viewCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		path := c.Coverage.Path
+		paths := c.Coverage.Paths
 		if reportPath != "" {
-			path = reportPath
+			paths = append(paths, reportPath)
 		}
-		if err := r.MeasureCoverage(path); err != nil {
+		if err := r.MeasureCoverage(paths); err != nil {
 			return err
 		}
 		for _, f := range args {

--- a/config/build.go
+++ b/config/build.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,8 +19,15 @@ func (c *Config) Build() {
 	if c.Coverage == nil {
 		c.Coverage = &ConfigCoverage{}
 	}
-	if c.Coverage.Path == "" {
-		c.Coverage.Path = filepath.Dir(c.path)
+	if c.Coverage.Paths == nil {
+		c.Coverage.Paths = []string{}
+	}
+	if c.Coverage.Path != "" {
+		_, _ = fmt.Fprintln(os.Stderr, "Deprecated error: coverage.path: has been deprecated. please use coverage.paths: instead.")
+		c.Coverage.Paths = append(c.Coverage.Paths, c.Coverage.Path)
+	}
+	if len(c.Coverage.Paths) == 0 {
+		c.Coverage.Paths = append(c.Coverage.Paths, filepath.Dir(c.path))
 	}
 
 	// CodeToTestRatio

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 
 type ConfigCoverage struct {
 	Path       string              `yaml:"path,omitempty"`
+	Paths      []string            `yaml:"paths,omitempty"`
 	Badge      ConfigCoverageBadge `yaml:"badge,omitempty"`
 	Acceptable string              `yaml:"acceptable,omitempty"`
 }

--- a/config/ready.go
+++ b/config/ready.go
@@ -13,8 +13,8 @@ func (c *Config) CoverageConfigReady() error {
 	if c.Coverage == nil {
 		return errors.New("coverage: is not set")
 	}
-	if c.Coverage.Path == "" {
-		return errors.New("coverage.path: is not set")
+	if len(c.Coverage.Paths) == 0 {
+		return errors.New("coverage.paths: is not set")
 	}
 	return nil
 }

--- a/config/ready_test.go
+++ b/config/ready_test.go
@@ -27,12 +27,12 @@ func TestCoverageConfigReady(t *testing.T) {
 			&Config{
 				Coverage: &ConfigCoverage{},
 			},
-			"coverage.path: is not set",
+			"coverage.paths: is not set",
 		},
 		{
 			&Config{
 				Coverage: &ConfigCoverage{
-					Path: "path/to/coverage.svg",
+					Paths: []string{"path/to/coverage.out"},
 				},
 			},
 			"",
@@ -293,7 +293,7 @@ func TestCoverageBadgeConfigReady(t *testing.T) {
 		{
 			&Config{
 				Coverage: &ConfigCoverage{
-					Path: "path/to/coverage.xml",
+					Paths: []string{"path/to/coverage.xml"},
 				},
 			},
 			"coverage.badge.path: is not set",
@@ -301,7 +301,7 @@ func TestCoverageBadgeConfigReady(t *testing.T) {
 		{
 			&Config{
 				Coverage: &ConfigCoverage{
-					Path: "path/to/coverage.xml",
+					Paths: []string{"path/to/coverage.xml"},
 					Badge: ConfigCoverageBadge{
 						Path: "path/to/coverage.svg",
 					},

--- a/report/diff_report_test.go
+++ b/report/diff_report_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestDiff(t *testing.T) {
 	a := &Report{}
-	if err := a.MeasureCoverage(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json")); err != nil {
+	if err := a.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json")); err != nil {
 		t.Fatal(err)
 	}
 	b := &Report{}
-	if err := b.MeasureCoverage(filepath.Join(testdataDir(t), "reports", "k1LoW", "awspec", "report.json")); err != nil {
+	if err := b.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "awspec", "report.json")); err != nil {
 		t.Fatal(err)
 	}
 	buf := new(bytes.Buffer)
@@ -29,11 +29,11 @@ func TestDiff(t *testing.T) {
 
 func TestDiffTable(t *testing.T) {
 	a := &Report{}
-	if err := a.MeasureCoverage(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json")); err != nil {
+	if err := a.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json")); err != nil {
 		t.Fatal(err)
 	}
 	b := &Report{}
-	if err := b.MeasureCoverage(filepath.Join(testdataDir(t), "reports", "k1LoW", "awspec", "report.json")); err != nil {
+	if err := b.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "awspec", "report.json")); err != nil {
 		t.Fatal(err)
 	}
 

--- a/report/report.go
+++ b/report/report.go
@@ -248,7 +248,9 @@ func (r *Report) MeasureCoverage(paths []string) error {
 		if r.Coverage == nil {
 			r.Coverage = cov
 		} else {
-			r.Coverage.Merge(cov)
+			if err := r.Coverage.Merge(cov); err != nil {
+				return err
+			}
 		}
 		r.rp = rp // TODO: multi paths
 	}

--- a/report/report.go
+++ b/report/report.go
@@ -221,25 +221,46 @@ func (r *Report) IsMeasuredTestExecutionTime() bool {
 	return r.TestExecutionTime != nil
 }
 
-func (r *Report) MeasureCoverage(path string) error {
-	cov, rp, cerr := challengeParseReport(path)
-	if cerr != nil {
-		f, err := os.Stat(path)
-		if err != nil || f.IsDir() {
-			return cerr
-		}
-		b, err := os.ReadFile(filepath.Clean(path))
-		if err != nil {
-			return err
-		}
-		if err := json.Unmarshal(b, r); err != nil {
-			return cerr
-		}
-		r.rp = path
-		return nil
+func (r *Report) Load(path string) error {
+	f, err := os.Stat(path)
+	if err != nil || f.IsDir() {
+		return fmt.Errorf("octocov report.json not found: %s", path)
 	}
-	r.Coverage = cov
-	r.rp = rp
+	b, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(b, r); err != nil {
+		return err
+	}
+	r.rp = path
+	return nil
+}
+
+func (r *Report) MeasureCoverage(paths []string) error {
+	var cerr error
+	for _, path := range paths {
+		cov, rp, err := challengeParseReport(path)
+		if err != nil {
+			cerr = err
+			continue
+		}
+		if r.Coverage == nil {
+			r.Coverage = cov
+		} else {
+			r.Coverage.Merge(cov)
+		}
+		r.rp = rp // TODO: multi paths
+	}
+
+	// fallback load report.json
+	if r.Coverage == nil || len(paths) == 0 {
+		path := paths[0]
+		if err := r.Load(path); err != nil {
+			return cerr
+		}
+	}
+
 	return nil
 }
 
@@ -428,5 +449,6 @@ func challengeParseReport(path string) (*coverage.Coverage, string, error) {
 	if cov, rp, err := coverage.NewCobertura().ParseReport(path); err == nil {
 		return cov, rp, nil
 	}
+
 	return nil, "", fmt.Errorf("coverage report not found: %s", path)
 }

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -56,7 +56,7 @@ func TestTable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		r := &Report{}
-		if err := r.MeasureCoverage(tt.path); err != nil {
+		if err := r.Load(tt.path); err != nil {
 			t.Fatal(err)
 		}
 		if got := r.Table(); got != tt.want {
@@ -89,7 +89,7 @@ func TestFileCoveagesTable(t *testing.T) {
 	}
 	path := filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json")
 	r := &Report{}
-	if err := r.MeasureCoverage(path); err != nil {
+	if err := r.Load(path); err != nil {
 		t.Fatal(err)
 	}
 	for _, tt := range tests {
@@ -181,11 +181,11 @@ func TestMergeExecutionTimes(t *testing.T) {
 
 func TestCompare(t *testing.T) {
 	a := &Report{}
-	if err := a.MeasureCoverage(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json")); err != nil {
+	if err := a.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json")); err != nil {
 		t.Fatal(err)
 	}
 	b := &Report{}
-	if err := b.MeasureCoverage(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json")); err != nil {
+	if err := b.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json")); err != nil {
 		t.Fatal(err)
 	}
 	got := a.Compare(b)


### PR DESCRIPTION
`coverage.path:` -> `coverage.paths:`