### PR TITLE
When merging coverage reports, if any one of them is not a TypeLOC, it should be TypeMerged.

### DIFF
--- a/pkg/coverage/merge.go
+++ b/pkg/coverage/merge.go
@@ -40,7 +40,7 @@ func (c *Coverage) Merge(c2 *Coverage) error {
 			return errors.New("can not merge: BlockCoverages are already deleted.")
 		}
 	}
-	if c.Type != c2.Type {
+	if c.Type != TypeLOC || c2.Type != TypeLOC {
 		c.Type = TypeMerged
 	}
 

--- a/pkg/coverage/merge_test.go
+++ b/pkg/coverage/merge_test.go
@@ -200,6 +200,54 @@ func TestMerge(t *testing.T) {
 				},
 			},
 		},
+		{
+			&Coverage{
+				Type: TypeLOC,
+				Files: FileCoverages{
+					&FileCoverage{
+						File: "file_a.go",
+						Blocks: BlockCoverages{
+							newBlockCoverage(TypeLOC, 1, -1, 1, -1, -1, 1),
+							newBlockCoverage(TypeLOC, 2, -1, 2, -1, -1, 0),
+							newBlockCoverage(TypeLOC, 3, -1, 3, -1, -1, 1),
+						},
+					},
+				},
+			},
+			&Coverage{
+				Type: TypeStmt,
+				Files: FileCoverages{
+					&FileCoverage{
+						File: "file_a.go",
+						Blocks: BlockCoverages{
+							newBlockCoverage(TypeStmt, 1, 0, 1, 10, 1, 1),
+							newBlockCoverage(TypeStmt, 2, 0, 2, 10, 1, 0),
+							newBlockCoverage(TypeStmt, 3, 0, 3, 10, 1, 1),
+						},
+					},
+				},
+			},
+			&Coverage{
+				Type:    TypeMerged,
+				Total:   3,
+				Covered: 2,
+				Files: FileCoverages{
+					&FileCoverage{
+						File:    "file_a.go",
+						Total:   3,
+						Covered: 2,
+						Blocks: BlockCoverages{
+							newBlockCoverage(TypeLOC, 1, -1, 1, -1, -1, 1),
+							newBlockCoverage(TypeLOC, 2, -1, 2, -1, -1, 0),
+							newBlockCoverage(TypeLOC, 3, -1, 3, -1, -1, 1),
+							newBlockCoverage(TypeStmt, 1, 0, 1, 10, 1, 1),
+							newBlockCoverage(TypeStmt, 2, 0, 2, 10, 1, 0),
+							newBlockCoverage(TypeStmt, 3, 0, 3, 10, 1, 1),
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		if err := tt.c1.Merge(tt.c2); err != nil {


### PR DESCRIPTION
Because the coverage counting method will be LOC.