### PR TITLE
Support for inserting code metrics report to body of pull request

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -17,6 +17,8 @@ comment:
   if: is_pull_request
 summary:
   if: is_pull_request
+body:
+  if: is_pull_request
 report:
   if: is_default_branch
   datastores:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -17,8 +17,8 @@ comment:
   if: is_pull_request
 summary:
   if: is_pull_request
-body:
-  if: is_pull_request
+# body:
+#   if: is_pull_request
 report:
   if: is_default_branch
   datastores:

--- a/README.md
+++ b/README.md
@@ -552,6 +552,22 @@ summary:
 
 The variables available in the `if` section are [here](https://github.com/k1LoW/octocov#if).
 
+### `body:`
+
+Set this if want to insert report to body of pull request.
+
+### `body.if:`
+
+Conditions for inserting report body of pull request.
+
+``` yaml
+# .octocov.yml
+body:
+  if: is_pull_request
+```
+
+The variables available in the `if` section are [here](https://github.com/k1LoW/octocov#if).
+
 ### `diff:`
 
 Configuration for comparing reports.

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/k1LoW/octocov/config"
+	"github.com/k1LoW/octocov/gh"
+)
+
+// replaceInsertReportToBody
+func replaceInsertReportToBody(ctx context.Context, c *config.Config, content, key string) error {
+	repo, err := gh.Parse(c.Repository)
+	if err != nil {
+		return err
+	}
+	g, err := gh.New()
+	if err != nil {
+		return err
+	}
+	n, err := g.DetectCurrentPullRequestNumber(ctx, repo.Owner, repo.Repo)
+	if err != nil {
+		return err
+	}
+	if err := g.ReplaceInsertToBody(ctx, repo.Owner, repo.Repo, n, content, key); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -378,6 +378,31 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		// Insert report to body of pull request
+		if err := c.BodyConfigReady(); err != nil {
+			cmd.PrintErrf("Skip inserting report to body of pull request: %v\n", err)
+		} else {
+			if err := func() error {
+				cmd.PrintErrln("Commenting report...")
+				if rPrev == nil {
+					cmd.PrintErrln("Skip comparing reports: previous report not found")
+				}
+				if err := c.DiffConfigReady(); err != nil {
+					cmd.PrintErrf("Skip comparing reports: %v\n", err)
+				}
+				content, err := createReportContent(ctx, c, r, rPrev, false)
+				if err != nil {
+					return err
+				}
+				if err := replaceInsertReportToBody(ctx, c, content, r.Key()); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				cmd.PrintErrf("Skip inserting report to body of pull request: %v\n", err)
+			}
+		}
+
 		// Store report
 		if err := c.ReportConfigReady(); err != nil {
 			cmd.PrintErrf("Skip storing report: %v\n", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -383,7 +383,7 @@ var rootCmd = &cobra.Command{
 			cmd.PrintErrf("Skip inserting report to body of pull request: %v\n", err)
 		} else {
 			if err := func() error {
-				cmd.PrintErrln("Commenting report...")
+				cmd.PrintErrln("Inserting report...")
 				if rPrev == nil {
 					cmd.PrintErrln("Skip comparing reports: previous report not found")
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Push              *ConfigPush              `yaml:"push,omitempty"`
 	Comment           *ConfigComment           `yaml:"comment,omitempty"`
 	Summary           *ConfigSummary           `yaml:"summary,omitempty"`
+	Body              *ConfigBody              `yaml:"body,omitempty"`
 	Diff              *ConfigDiff              `yaml:"diff,omitempty"`
 	GitRoot           string                   `yaml:"-"`
 	// working directory
@@ -112,6 +113,10 @@ type ConfigComment struct {
 }
 
 type ConfigSummary struct {
+	If string `yaml:"if,omitempty"`
+}
+
+type ConfigBody struct {
 	If string `yaml:"if,omitempty"`
 }
 

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -21,6 +21,7 @@ func (c *Config) UnmarshalYAML(data []byte) error {
 		Push              interface{}              `yaml:"push,omitempty"`
 		Comment           interface{}              `yaml:"comment,omitempty"`
 		Summary           *ConfigSummary           `yaml:"summary,omitempty"`
+		Body              *ConfigBody              `yaml:"body,omitempty"`
 		Diff              *ConfigDiff              `yaml:"diff,omitempty"`
 	}{}
 	err := yaml.Unmarshal(data, &s)
@@ -34,6 +35,7 @@ func (c *Config) UnmarshalYAML(data []byte) error {
 	c.Report = s.Report
 	c.Central = s.Central
 	c.Summary = s.Summary
+	c.Body = s.Body
 	c.Diff = s.Diff
 
 	switch v := s.Comment.(type) {

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -275,9 +275,12 @@ func (g *Gh) ReplaceInsertToBody(ctx context.Context, owner, repo string, number
 	current := pr.GetBody()
 	var rep string
 	if strings.Count(current, sig) < 2 {
-		rep = fmt.Sprintf("%s\n%s\n%s\n%s", current, sig, content, sig)
+		rep = fmt.Sprintf("%s\n%s\n%s\n%s\n", current, sig, content, sig)
 	} else {
 		buf := new(bytes.Buffer)
+		if !strings.HasSuffix(current, "\n") {
+			current += "\n"
+		}
 		if _, err := repin.Replace(strings.NewReader(current), strings.NewReader(content), sig, sig, false, buf); err != nil {
 			return err
 		}

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -267,17 +267,18 @@ func (g *Gh) DetectCurrentPullRequestNumber(ctx context.Context, owner, repo str
 }
 
 func (g *Gh) ReplaceInsertToBody(ctx context.Context, owner, repo string, number int, content, key string) error {
+	sig := generateSig(key)
 	pr, _, err := g.client.PullRequests.Get(ctx, owner, repo, number)
 	if err != nil {
 		return err
 	}
 	current := pr.GetBody()
 	var rep string
-	if strings.Count(current, key) < 2 {
-		rep = fmt.Sprintf("%s\n%s\n%s\n%s", current, key, content, key)
+	if strings.Count(current, sig) < 2 {
+		rep = fmt.Sprintf("%s\n%s\n%s\n%s", current, sig, content, sig)
 	} else {
 		buf := new(bytes.Buffer)
-		if _, err := repin.Replace(strings.NewReader(current), strings.NewReader(content), key, key, false, buf); err != nil {
+		if _, err := repin.Replace(strings.NewReader(current), strings.NewReader(content), sig, sig, false, buf); err != nil {
 			return err
 		}
 		rep = buf.String()

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -283,8 +283,9 @@ func (g *Gh) ReplaceInsertToBody(ctx context.Context, owner, repo string, number
 		}
 		rep = buf.String()
 	}
-	pr.Body = &rep
-	if _, _, err := g.client.PullRequests.Edit(ctx, owner, repo, number, pr); err != nil {
+	if _, _, err := g.client.PullRequests.Edit(ctx, owner, repo, number, &github.PullRequest{
+		Body: &rep,
+	}); err != nil {
 		return err
 	}
 	return nil

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-github/v45/github"
 	"github.com/k1LoW/go-github-actions/artifact"
 	"github.com/k1LoW/go-github-client/v45/factory"
+	"github.com/k1LoW/repin"
 	"github.com/lestrrat-go/backoff/v2"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
@@ -263,6 +264,29 @@ func (g *Gh) DetectCurrentPullRequestNumber(ctx context.Context, owner, repo str
 		return d.GetNumber(), nil
 	}
 	return 0, errors.New("could not detect number of pull request")
+}
+
+func (g *Gh) ReplaceInsertToBody(ctx context.Context, owner, repo string, number int, content, key string) error {
+	pr, _, err := g.client.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		return err
+	}
+	current := pr.GetBody()
+	var rep string
+	if strings.Count(current, key) < 2 {
+		rep = fmt.Sprintf("%s\n%s\n%s\n%s", current, key, content, key)
+	} else {
+		buf := new(bytes.Buffer)
+		if _, err := repin.Replace(strings.NewReader(current), strings.NewReader(content), key, key, false, buf); err != nil {
+			return err
+		}
+		rep = buf.String()
+	}
+	pr.Body = &rep
+	if _, _, err := g.client.PullRequests.Edit(ctx, owner, repo, number, pr); err != nil {
+		return err
+	}
+	return nil
 }
 
 type PullRequest struct {

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/k1LoW/ghfs v0.7.0
 	github.com/k1LoW/go-github-actions v0.0.2
 	github.com/k1LoW/go-github-client/v45 v45.2.3
+	github.com/k1LoW/repin v0.3.2
 	github.com/lestrrat-go/backoff/v2 v2.0.8
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mauri870/gcsfs v0.0.0-20220203135357-0da01ba4e96d

--- a/go.sum
+++ b/go.sum
@@ -396,6 +396,8 @@ github.com/k1LoW/go-github-actions v0.0.2 h1:rcoqhkNSihfuNdMzEC0m66OR8nxd7V6OEHe
 github.com/k1LoW/go-github-actions v0.0.2/go.mod h1:qDfnEZDByCWZ4geyn4jDDnbWiZIKcGbc2+cgdip04UA=
 github.com/k1LoW/go-github-client/v45 v45.2.3 h1:VgL8bLfDfppHJTrCZQ826R+P4Np9+kOJXP0i0NQAqao=
 github.com/k1LoW/go-github-client/v45 v45.2.3/go.mod h1:c6rHQhBuUN+Ljzi9e2tvv3EPlijIRnOEFyQiD+H0rkE=
+github.com/k1LoW/repin v0.3.2 h1:rX4F0ktNmxcUd3iG2sFrxJ21Hp+BjzFDoVAurCiVJYI=
+github.com/k1LoW/repin v0.3.2/go.mod h1:GQqmitWePjIJEpQ0aOJYgn4rKF6LF6iHu4RXO2v1Qk4=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=


### PR DESCRIPTION
Support for inserting code metrics report to body of pull request.

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/k1LoW/octocov/tree/main) ([39c8672](https://github.com/k1LoW/octocov/commit/39c86726b00af42e6cd0d94430a2c1c5ef8974d7)) | [#172](https://github.com/k1LoW/octocov/pull/172) ([c666757](https://github.com/k1LoW/octocov/commit/c6667577b1be6a25da1beae81b2ad630deb9ad7f)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                            65.7% |                                                                                                                                           64.8% | -1.0% |
| **Code to Test Ratio**  |                                                                                                                                            1:0.4 |                                                                                                                                           1:0.4 |  -0.0 |
| **Test Execution Time** |                                                                                                                                              33s |                                                                                                                                             44s |  +11s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (39c8672) | #172 (c666757) |  +/-  |
  |---------------------|----------------|----------------|-------|
- | Coverage            |          65.7% |          64.8% | -1.0% |
  |   Files             |             29 |             29 |     0 |
  |   Lines             |           2446 |           2485 |   +39 |
+ |   Covered           |           1608 |           1610 |    +2 |
- | Code to Test Ratio  |          1:0.4 |          1:0.4 |  -0.0 |
  |   Code              |           6333 |           6445 |  +112 |
  |   Test              |           2840 |           2840 |     0 |
- | Test Execution Time |            33s |            44s |  +11s |
```

</details>


### Code coverage of files in pull request scope (41.1% → 39.2%)

|                                                         Files                                                         | Coverage |  +/-  |
|-----------------------------------------------------------------------------------------------------------------------|---------:|------:|
| [config/config.go](https://github.com/k1LoW/octocov/blob/19d6ea8b0c67146236e9be36fb99b11950573e4b/config%2Fconfig.go) | 58.5%    | +0.6% |
| [config/ready.go](https://github.com/k1LoW/octocov/blob/19d6ea8b0c67146236e9be36fb99b11950573e4b/config%2Fready.go)   | 59.9%    | -9.6% |
| [config/yaml.go](https://github.com/k1LoW/octocov/blob/19d6ea8b0c67146236e9be36fb99b11950573e4b/config%2Fyaml.go)     | 78.6%    | +0.4% |
| [gh/gh.go](https://github.com/k1LoW/octocov/blob/19d6ea8b0c67146236e9be36fb99b11950573e4b/gh%2Fgh.go)                 | 15.5%    | -0.8% |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
