### PR TITLE
Release for v0.43.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v0.43.1](https://github.com/k1LoW/octocov/compare/v0.44.0...v0.43.1) - 2022-10-13
+
 ## [v0.44.0](https://github.com/k1LoW/octocov/compare/v0.43.2...v0.44.0) (2022-10-12)
 
 * Update pkgs [#189](https://github.com/k1LoW/octocov/pull/189) ([k1LoW](https://github.com/k1LoW))


### PR DESCRIPTION
This pull request is for the next release as v0.43.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.43.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.44.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at v0.43.1 -->



**Full Changelog**: https://github.com/k1LoW/octocov/compare/v0.44.0...v0.43.1