### PR TITLE
test: add case for https://github.com/antonmedv/expr expression supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,8 @@ The variables available in the `if` section are [here](https://github.com/k1LoW/
 
 ### `*.if:`
 
+> **Note**: It supports [antonmedv/expr](https://github.com/antonmedv/expr) expressions.
+
 The variables available in the `if` section are as follows
 
 | Variable name | Type | Description |

--- a/config/ready_test.go
+++ b/config/ready_test.go
@@ -689,6 +689,19 @@ func TestReportConfigReady(t *testing.T) {
 			},
 			"the condition in the `if` section is not met (false)",
 		},
+		{
+			&Config{
+				Repository: "owner/repo",
+				Report: &ConfigReport{
+					Datastores: []string{
+						"s3://bucket/reports",
+					},
+					If: "env.GITHUB_EVENT_NAME startsWith \"pull\"",
+				},
+				gh: mg,
+			},
+			"the condition in the `if` supports ",
+		},
 	}
 	for _, tt := range tests {
 		err := tt.c.ReportConfigReady()


### PR DESCRIPTION
The if property uses [https://github.com/antonmedv/expr.Eval](https://github.com/k1LoW/octocov/blob/main/config/config.go#L438). So I added a test case and added that the antonmedv/expr expression can be used in the document.

