### PR TITLE
feat: customize commit message by octocov.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,16 @@ push:
 
 The variables available in the `if` section are [here](https://github.com/k1LoW/octocov#if).
 
+### `push.message:`
+
+message for commit.
+
+``` yaml
+# .octocov.yml
+push:
+  message: Update by octocov [skip-ci]
+```
+
 ### `comment:`
 
 Set this if want to comment report to pull request

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ message for commit.
 ``` yaml
 # .octocov.yml
 push:
-  message: Update by octocov [skip-ci]
+  message: Update by octocov [skip ci]
 ```
 
 ### `comment:`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,7 +140,13 @@ var rootCmd = &cobra.Command{
 				cmd.PrintErrf("Skip commit and push central report: %v\n", err)
 			} else {
 				cmd.PrintErrln("Commit and push central report")
-				if err := gh.PushUsingLocalGit(ctx, c.GitRoot, paths, "Update by octocov"); err != nil {
+
+				commitMessage := "Update by octocov"
+				if c.Central.Push.Message != "" {
+					commitMessage = c.Central.Push.Message
+				}
+
+				if err := gh.PushUsingLocalGit(ctx, c.GitRoot, paths, commitMessage); err != nil {
 					return err
 				}
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -443,7 +443,13 @@ var rootCmd = &cobra.Command{
 			cmd.PrintErrf("Skip pushing generate files: %v\n", err)
 		} else {
 			cmd.PrintErrln("Pushing generated files...")
-			if err := gh.PushUsingLocalGit(ctx, c.GitRoot, addPaths, "Update by octocov"); err != nil {
+
+			commitMessage := "Update by octocov"
+			if c.Push.Message != "" {
+				commitMessage = c.Push.Message
+			}
+
+			if err := gh.PushUsingLocalGit(ctx, c.GitRoot, addPaths, commitMessage); err != nil {
 				return err
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -104,7 +104,8 @@ type ConfigCentralBadges struct {
 }
 
 type ConfigPush struct {
-	If string `yaml:"if,omitempty"`
+	If      string `yaml:"if,omitempty"`
+	Message string `yaml:"message,omitempty"`
 }
 
 type ConfigComment struct {

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -674,6 +674,7 @@ func PushUsingLocalGit(ctx context.Context, gitRoot string, addPaths []string, m
 	}
 
 	if !push {
+		fmt.Println("No files to be commit.")
 		return nil
 	}
 


### PR DESCRIPTION
Currently the commit message is a fixed string, but I made it editable in octocov.yml. This is used when you want to control triggering of ci by commit message.

Examples: [skip ci], [actions skip], etc...
https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs

I also noticed that I wasn't getting a message at all if there were no files to commit, so I added that as well. If it's better to split the PR, create a new separate PR