### PR TITLE
Fix panic when adding codeToTestRatio for the first time

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -371,7 +371,7 @@ func (r *Report) CoveragePercent() float64 {
 }
 
 func (r *Report) CodeToTestRatioRatio() float64 {
-	if r.CodeToTestRatio.Code == 0 {
+	if r.CodeToTestRatio == nil || r.CodeToTestRatio.Code == 0 {
 		return 0.0
 	}
 	return float64(r.CodeToTestRatio.Test) / float64(r.CodeToTestRatio.Code)


### PR DESCRIPTION
Hi, first of all, thank you for this great tool!

This pull request solves the following error.

```
octocov version 0.47.3

                       #57[6](https://github.com/[REDACTED]#step:8:7) (51ec1b8)  
---------------------------------------
  Coverage                      34.4%  
  Code to Test Ratio            1:0.4  
  Test Execution Time           1m15s  

Skip commenting report to pull request: comment: is not set
Skip adding report to job summary page: summary: is not set
Inserting report...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc[7](https://github.com/[REDACTED]#step:8:8)0ddc]

goroutine 1 [running]:
github.com/k1LoW/octocov/report.(*Report).CodeToTestRatioRatio(...)
	/workdir/report/report.go:374
github.com/k1LoW/octocov/config.(*Config).Acceptable(0xc0015d3540, 0xc0001e9700, 0xc001a76000)
	/workdir/config/config.go:203 +0x17c
github.com/k1LoW/octocov/cmd.createReportContent({0x1f9[8](https://github.com/[REDACTED]#step:8:9)1d0, 0xc000126000}, 0xc0015d3540, 0xc00004fe00?, 0xc001a76000, 0x0)
	/workdir/cmd/comment.go:78 +0x2a5
github.com/k1LoW/octocov/cmd.glob..func7.6(0xc0015d3540?, 0xc001a76000, 0xc0015d3540, {0x1f[9](https://github.com/[REDACTED]#step:8:10)81d0, 0xc000126000}, 0x2?)
	/workdir/cmd/root.go:420 +0x137
github.com/k1LoW/octocov/cmd.glob..func7(0x2f28380?, {0x317a878?, 0x0?, 0x0?})
	/workdir/cmd/root.go:428 +0x18ab
github.com/spf13/cobra.(*Command).execute(0x2f28380, {0xc0001121e0, 0x0, 0x0})
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x2f28380)
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:[10](https://github.com/[REDACTED]#step:8:11)44 +0x3bd
github.com/spf[13](https://github.com/[REDACTED]#step:8:14)/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/k1LoW/octocov/cmd.Execute()
	/workdir/cmd/root.go:598 +0xdb
main.main()
	/workdir/main.go:48 +0x[15](https://github.com/[REDACTED]#step:8:16)e
```

You can reproduce this error with the following
1. Save a previous report without codeToTestRatio
2. Add codeToTestRatio settings to octocov config
