### PR TITLE
`octocov ls-files` and `octocov view` should run locally as much as possible.

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,4 +1,5 @@
 coverage:
+  if: true
   acceptable: current >= 60%
 codeToTestRatio:
   code:

--- a/cmd/lsFiles.go
+++ b/cmd/lsFiles.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -53,8 +54,8 @@ var lsFilesCmd = &cobra.Command{
 			c.CodeToTestRatio = nil
 			c.TestExecutionTime = nil
 		}
-		if err := c.CoverageConfigReady(); err != nil {
-			return err
+		if c.Coverage == nil {
+			return errors.New("coverage: is not set")
 		}
 		r, err := report.New(c.Repository)
 		if err != nil {

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -49,8 +50,8 @@ var viewCmd = &cobra.Command{
 			c.CodeToTestRatio = nil
 			c.TestExecutionTime = nil
 		}
-		if err := c.CoverageConfigReady(); err != nil {
-			return err
+		if c.Coverage == nil {
+			return errors.New("coverage: is not set")
 		}
 		r, err := report.New(c.Repository)
 		if err != nil {


### PR DESCRIPTION
Fix #291 