### PR TITLE
[Feature Reqeust] Add message to code metrics report

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,15 @@ comment:
   deletePrevious: true
 ```
 
+### `comment.message:`
+
+Add message to code metrics report comments.
+
+```yaml
+comment:
+  message: See [coverage html](https://github.com/k1LoW/octocov).
+```
+
 ### `comment.if:`
 
 Conditions for commenting report.
@@ -609,6 +618,15 @@ summary:
   hideFooterLink: true
 ```
 
+### `summary.message:`
+
+Add message to report.
+
+```yaml
+summary:
+  message: See [coverage html](https://github.com/k1LoW/octocov).
+```
+
 ### `summary.if:`
 
 Conditions for adding report to job summary page.
@@ -632,6 +650,15 @@ Hide footer [octocov](https://github.com/k1LoW/octocov) link.
 ``` yaml
 body:
   hideFooterLink: true
+```
+
+### `body.message:`
+
+Add message to report.
+
+```yaml
+body:
+  message: See [coverage html](https://github.com/k1LoW/octocov).
 ```
 
 ### `body.if:`

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -36,7 +36,7 @@ func commentReport(ctx context.Context, c *config.Config, content, key string) e
 	return nil
 }
 
-func createReportContent(ctx context.Context, c *config.Config, r, rPrev *report.Report, hideFooterLink bool) (string, error) {
+func createReportContent(ctx context.Context, c *config.Config, r, rPrev *report.Report, message string, hideFooterLink bool) (string, error) {
 	repo, err := gh.Parse(c.Repository)
 	if err != nil {
 		return "", err
@@ -84,6 +84,9 @@ func createReportContent(ctx context.Context, c *config.Config, r, rPrev *report
 	var comment []string
 	if r.IsMeasuredCoverage() || r.IsMeasuredTestExecutionTime() || r.IsMeasuredCodeToTestRatio() {
 		comment = append(comment, fmt.Sprintf("## %s", r.Title()))
+	}
+	if message != "" {
+		comment = append(comment, message)
 	}
 	if err := c.Acceptable(r, rPrev); err != nil {
 		merr, ok := err.(*multierror.Error) //nolint:errorlint

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -378,7 +378,7 @@ var rootCmd = &cobra.Command{
 				if err := c.DiffConfigReady(); err != nil {
 					cmd.PrintErrf("Skip comparing reports: %v\n", err)
 				}
-				content, err := createReportContent(ctx, c, r, rPrev, c.Comment.HideFooterLink)
+				content, err := createReportContent(ctx, c, r, rPrev, c.Comment.Message, c.Comment.HideFooterLink)
 				if err != nil {
 					return err
 				}
@@ -403,7 +403,7 @@ var rootCmd = &cobra.Command{
 				if err := c.DiffConfigReady(); err != nil {
 					cmd.PrintErrf("Skip comparing reports: %v\n", err)
 				}
-				content, err := createReportContent(ctx, c, r, rPrev, c.Summary.HideFooterLink)
+				content, err := createReportContent(ctx, c, r, rPrev, c.Summary.Message, c.Summary.HideFooterLink)
 				if err != nil {
 					return err
 				}
@@ -428,7 +428,7 @@ var rootCmd = &cobra.Command{
 				if err := c.DiffConfigReady(); err != nil {
 					cmd.PrintErrf("Skip comparing reports: %v\n", err)
 				}
-				content, err := createReportContent(ctx, c, r, rPrev, c.Body.HideFooterLink)
+				content, err := createReportContent(ctx, c, r, rPrev, c.Body.Message, c.Body.HideFooterLink)
 				if err != nil {
 					return err
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -119,16 +119,19 @@ type Push struct {
 type Comment struct {
 	HideFooterLink bool   `yaml:"hideFooterLink"`
 	DeletePrevious bool   `yaml:"deletePrevious"`
+	Message        string `yaml:"message,omitempty"`
 	If             string `yaml:"if,omitempty"`
 }
 
 type Summary struct {
 	HideFooterLink bool   `yaml:"hideFooterLink"`
+	Message        string `yaml:"message,omitempty"`
 	If             string `yaml:"if,omitempty"`
 }
 
 type Body struct {
 	HideFooterLink bool   `yaml:"hideFooterLink"`
+	Message        string `yaml:"message,omitempty"`
 	If             string `yaml:"if,omitempty"`
 }
 


### PR DESCRIPTION
Hi, octocov is working well on our project. Thank you for great tool.

## Motivation

I wanna propose the setting of `octocov.yaml` to add extra message such as the link of hosted `coverage.html` to code metrics report. Let me know if you have better way.

## Usage

For instance, we can add the flexible message with environment variable like the following.

```
# .octocov.ymal
# pass OCOTOCOV_COV_LINK="https://example.com/abc/coverage.html"

comment:
  message: See [coverage html](${COV_LINK})

```