### PR TITLE
ci: update CI workflow and Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,20 +36,19 @@ jobs:
           fail_on_error: true
           golangci_lint_flags: --timeout=5m
 
-      - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: '${{ steps.setup-go.outputs.go-version }}'
-          check-latest: true
-          cache: false
-          go-package: ./...
-
       - name: Run gostyle
         uses: k1LoW/gostyle-action@v1
         with:
-          go-version-input: '${{ steps.setup-go.outputs.go-version }}'
-          fail-on-error: true
           config-file: .gostyle.yml
+          fail-on-error: true
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ''
+          go-version-file: go.mod
+          repo-checkout: false
+          go-package: ./...
 
       - name: Run tests
         run: make ci

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k1LoW/octocov
 
-go 1.23.6
+go 1.23.7
 
 require (
 	cloud.google.com/go/bigquery v1.66.2


### PR DESCRIPTION
This pull request includes updates to the CI workflow configuration and a minor version update in the `go.mod` file. The most important changes are as follows:

### CI Workflow Configuration:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL39-R51): Reordered and updated the `govulncheck` step to use `go-version-file` and `repo-checkout` parameters.

### Dependency Management:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.23.6` to `1.23.7`.