### PR TITLE
migrate .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,37 @@
+version: "2"
 linters:
-  fast: false
   enable:
-    - misspell
-    - gosec
-    - godot
-    - revive
     - errorlint
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  misspell:
-    locale: US
-    ignore-words: []
-  revive:
-    rules:
-      - name: unexported-return
-        disabled: true
-      - name: exported
-        disabled: false
+    - godot
+    - gosec
+    - misspell
+    - revive
+  settings:
+    errcheck:
+      check-type-assertions: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: unexported-return
+          disabled: true
+        - name: exported
+          disabled: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
https://github.com/reviewdog/action-golangci-lint/releases/tag/v2.8.0

[action-golangci](https://github.com/reviewdog/action-golangci-lint) was updated to v2.8.0 3 days ago. That contains migrating to golangci-lint v2, so this repository maybe also need to migrate.

I noticed that when I forked this repo and was trying to run Github Actions.

I just ran `golangci-lint migrate` and pushed the generated yml.