### PR TITLE
Add status of diff files on PR report

### DIFF
--- a/gh/gh.go
+++ b/gh/gh.go
@@ -318,6 +318,7 @@ func (g *Gh) FetchPullRequest(ctx context.Context, owner, repo string, number in
 type PullRequestFile struct {
 	Filename string
 	BlobURL  string
+	Status   string
 }
 
 func (g *Gh) FetchPullRequestFiles(ctx context.Context, owner, repo string, number int) ([]*PullRequestFile, error) {
@@ -338,6 +339,7 @@ func (g *Gh) FetchPullRequestFiles(ctx context.Context, owner, repo string, numb
 			files = append(files, &PullRequestFile{
 				Filename: f.GetFilename(),
 				BlobURL:  f.GetBlobURL(),
+				Status:   f.GetStatus(),
 			})
 		}
 		page += 1

--- a/report/diff_report.go
+++ b/report/diff_report.go
@@ -278,7 +278,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile) string {
 			pc += fc.FileCoverageB.Covered
 			pt += fc.FileCoverageB.Total
 		}
-		rows = append(rows, []string{fmt.Sprintf("[%s](%s)", f.Filename, f.BlobURL), fmt.Sprintf("%.1f%%", floor1(fc.A)), diff})
+		rows = append(rows, []string{fmt.Sprintf("[%s](%s)", f.Filename, f.BlobURL), fmt.Sprintf("%.1f%%", floor1(fc.A)), diff, f.Status})
 	}
 	if !exist {
 		return ""
@@ -306,7 +306,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile) string {
 	}
 
 	table := tablewriter.NewWriter(buf)
-	h := []string{"Files", "Coverage", "+/-"}
+	h := []string{"Files", "Coverage", "+/-", "Status"}
 	table.SetHeader(h)
 	table.SetAutoFormatHeaders(false)
 	table.SetAutoWrapText(false)


### PR DESCRIPTION
I implemented the feature that is add a status column on diff files report in a pull request.

For now, I simply add `Status` parameter and put it in a table of PR report. If needed, I would be happy to implement this feature as an option, branching based on parameters in `.octocov.yml` file.

<img width="951" alt="image" src="https://github.com/user-attachments/assets/5bef792a-318f-4fe3-8d5f-fd3ba2c138ec" />
