### PR TITLE
cmd: Append subcommands help into `badge` help message

### DIFF
--- a/cmd/badge.go
+++ b/cmd/badge.go
@@ -47,7 +47,7 @@ var outPath string
 
 // badgeCmd represents the badge command.
 var badgeCmd = &cobra.Command{
-	Use:       "badge",
+	Use:       "badge <coverage|ratio|time>",
 	Short:     "generate badge",
 	Long:      `generate badge.`,
 	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),


### PR DESCRIPTION
## WHAT

This PR updates the `Use` field of the `badge` command to explicitly include the required subcommand names.
This makes the help output display the required argument for the first time, improving clarity for users.

**Before:**

```
❯ go run main.go badge --help
generate badge.

Usage:
  octocov badge [flags]

Flags:
      --config string   config file path
  -h, --help            help for badge
      --out string      output file path
```

**After:**

```
❯ go run main.go badge --help
generate badge.

Usage:
  octocov badge <coverage|ratio|time> [flags]

Flags:
      --config string   config file path
  -h, --help            help for badge
      --out string      output file path
```


## WHY

- https://github.com/k1LoW/octocov/issues/523