### PR TITLE
fix: DiffReport.FileCoveragesTable file name & path

### DIFF
--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -73,7 +73,7 @@ func createReportContent(ctx context.Context, c *config.Config, r, rPrev *report
 	if rPrev != nil {
 		d := r.Compare(rPrev)
 		table = d.Table()
-		fileTable = d.FileCoveragesTable(files)
+		fileTable = d.FileCoveragesTable(files, c.Wd())
 		for _, s := range d.CustomMetrics {
 			customTables = append(customTables, s.Table(), s.MetadataTable())
 		}

--- a/report/diff_report.go
+++ b/report/diff_report.go
@@ -253,7 +253,7 @@ func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.C
 	}
 }
 
-func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile) string {
+func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, wd string) string {
 	if d.Coverage == nil {
 		return ""
 	}
@@ -289,7 +289,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile) string {
 
 	for _, fc := range d.Coverage.Files {
 		if prf, ok := prFiles[fc.File]; ok {
-			name := fmt.Sprintf("[%s](%s)", prf.Filename, prf.BlobURL)
+			name := fmt.Sprintf("[%s](%s)", strings.TrimPrefix(prf.Filename, wd+"/"), prf.BlobURL)
 			rows = append(rows, createRow(name, fc, prf.Status))
 			continue
 		}
@@ -297,17 +297,24 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile) string {
 			continue
 		}
 
-		name := fc.File
 		repoURL := fmt.Sprintf("%s/%s", os.Getenv("GITHUB_SERVER_URL"), os.Getenv("GITHUB_REPOSITORY"))
+		// trim prefix for Go coverage (no sufficient checks on the other formats)
+		name := strings.TrimPrefix(fc.File, strings.TrimPrefix(repoURL, "https://")+"/")
 		commit := ""
 		if fc.FileCoverageA != nil && d.CommitA != "" {
 			commit = d.CommitA
 		} else if fc.FileCoverageB != nil && d.CommitB != "" {
 			commit = d.CommitB
 		}
-		filePath := strings.TrimLeft(fc.File, repoURL)
-		if repoURL != "/" && repoURL != "" && commit != "" && !filepath.IsAbs(filePath) {
-			name = fmt.Sprintf("[%s](%s/blob/%s/%s)", filePath, repoURL, commit, filePath)
+
+		filePath := name
+		filePath = strings.TrimPrefix(filePath, repoURL)
+		if wd != "" && !strings.HasPrefix(filePath, wd+"/") && !filepath.IsAbs(filePath) {
+			filePath = filepath.Clean(filepath.Join(wd, filePath))
+		}
+
+		if repoURL != "/" && commit != "" && !filepath.IsAbs(filePath) {
+			name = fmt.Sprintf("[%s](%s/blob/%s/%s)", name, repoURL, commit, filePath)
 		}
 		rows = append(rows, createRow(name, fc, "affected"))
 	}

--- a/report/diff_report_test.go
+++ b/report/diff_report_test.go
@@ -75,7 +75,7 @@ func TestDiffFileCoveragesTable(t *testing.T) {
 		{Filename: "zcase/removed.go", BlobURL: "https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed.go", Status: "removed"},
 		{Filename: "zcase/removed_test.go", BlobURL: "https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed_test.go", Status: "removed"},
 		{Filename: "zcase/rename_new.go", BlobURL: "https://github.com/k1LoW/octocov/blob/afterhash/zcase/rename_new.go", Status: "renamed"},
-	})
+	}, "")
 	f := "diff_file_coverages_table"
 	if os.Getenv("UPDATE_GOLDEN") != "" {
 		golden.Update(t, testdataDir(t), f, got)


### PR DESCRIPTION
Fix: the bug introduced in #536

This pull request updates the way file coverage tables are generated and displayed, specifically improving how file paths are handled and shown in coverage reports. The changes ensure that file paths are consistently trimmed and cleaned, resulting in more readable links and accurate coverage information. Additionally, the relevant test has been updated to reflect the new method signature.

### Coverage Report Improvements

* Modified the `FileCoveragesTable` method in `report/diff_report.go` to accept the working directory (`wd`) as an argument, allowing for more precise trimming of file path prefixes for better readability.
* Improved file path handling by trimming the working directory prefix from filenames in coverage tables and cleaning up file paths before generating links, resulting in clearer and more accurate file references in reports. [[1]](diffhunk://#diff-24c1ce9644500e6944ff90c079bb38897c775553053acf142ca989c2310def87L292-R292) [[2]](diffhunk://#diff-24c1ce9644500e6944ff90c079bb38897c775553053acf142ca989c2310def87L308-R317)
* Updated the call to `FileCoveragesTable` in `cmd/comment.go` to pass the working directory, ensuring consistent path trimming in report generation.
