### PR TITLE
fix: update FileCoveragesTable to use relative working directory

### DIFF
--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -73,7 +74,16 @@ func createReportContent(ctx context.Context, c *config.Config, r, rPrev *report
 	if rPrev != nil {
 		d := r.Compare(rPrev)
 		table = d.Table()
-		fileTable = d.FileCoveragesTable(files, c.Wd())
+		relWd := c.Root()
+		if c.GitRoot != "" {
+			if rw, err := filepath.Rel(c.GitRoot, c.Root()); err == nil {
+				relWd = filepath.ToSlash(rw)
+			}
+		}
+		if relWd == "." {
+			relWd = ""
+		}
+		fileTable = d.FileCoveragesTable(files, relWd)
 		for _, s := range d.CustomMetrics {
 			customTables = append(customTables, s.Table(), s.MetadataTable())
 		}

--- a/report/diff_report.go
+++ b/report/diff_report.go
@@ -253,7 +253,7 @@ func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.C
 	}
 }
 
-func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, wd string) string {
+func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd string) string {
 	if d.Coverage == nil {
 		return ""
 	}
@@ -289,7 +289,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, wd string) 
 
 	for _, fc := range d.Coverage.Files {
 		if prf, ok := prFiles[fc.File]; ok {
-			name := fmt.Sprintf("[%s](%s)", strings.TrimPrefix(prf.Filename, wd+"/"), prf.BlobURL)
+			name := fmt.Sprintf("[%s](%s)", prf.Filename, prf.BlobURL)
 			rows = append(rows, createRow(name, fc, prf.Status))
 			continue
 		}
@@ -308,13 +308,12 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, wd string) 
 		}
 
 		filePath := name
-		filePath = strings.TrimPrefix(filePath, repoURL)
-		if wd != "" && !strings.HasPrefix(filePath, wd+"/") && !filepath.IsAbs(filePath) {
-			filePath = filepath.Clean(filepath.Join(wd, filePath))
+		if relWd != "" && !strings.HasPrefix(filePath, relWd+"/") && !filepath.IsAbs(filePath) {
+			filePath = filepath.Clean(filepath.Join(relWd, filePath))
 		}
 
 		if repoURL != "/" && commit != "" && !filepath.IsAbs(filePath) {
-			name = fmt.Sprintf("[%s](%s/blob/%s/%s)", name, repoURL, commit, filePath)
+			name = fmt.Sprintf("[%s](%s/blob/%s/%s)", filePath, repoURL, commit, filePath)
 		}
 		rows = append(rows, createRow(name, fc, "affected"))
 	}


### PR DESCRIPTION
This pull request updates how file paths are handled and displayed in coverage tables, primarily to improve accuracy and consistency when generating file links in reports. The changes focus on using relative paths based on the repository root and simplifying file name handling.

**File path handling and display improvements:**

* The logic in `cmd/comment.go` now computes a relative working directory (`relWd`) based on the repository root (`GitRoot`) and working directory (`Root`), ensuring file paths are consistently relative to the repo root.
* The `FileCoveragesTable` method signature in `report/diff_report.go` was updated to accept `relWd` instead of `wd`, reflecting the new approach to path calculation.
* When rendering file names in coverage tables, the code now directly uses the file name from the pull request file (`prf.Filename`), removing the previous logic that trimmed the working directory prefix. This simplifies file name presentation.
* File path construction for affected files now uses `relWd` instead of `wd`, and the logic for link generation has been updated to use the file path as the link text, improving clarity and consistency in report output.
