### PR TITLE
fix: fix GitRoot in config

### DIFF
--- a/config/build.go
+++ b/config/build.go
@@ -63,6 +63,6 @@ func (c *Config) Build() {
 	// Diff
 
 	// GitRoot
-	gitRoot, _ := internal.RootPath(c.Root()) //nostyle:handlerrors
+	gitRoot, _ := internal.GitRoot(c.Root()) //nostyle:handlerrors
 	c.GitRoot = gitRoot
 }


### PR DESCRIPTION
This pull request updates the logic for determining the Git root directory in the `Build()` method of the `Config` struct. Instead of using the `RootPath` function, it now uses the more appropriately named `GitRoot` function from the `internal` package.

Refactoring for clarity and correctness:

* Updated the call in `config/build.go` to use `internal.GitRoot` instead of `internal.RootPath` when setting the `GitRoot` field in the `Config` struct.