### PR TITLE
fix: support artifact re-upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,14 @@ jobs:
           OCTOCOV_CUSTOM_METRICS_BENCHMARK_0: ./testdata/custom_metrics/benchmark_0.json
           GOTOOLCHAIN: 'go${{ steps.setup-go.outputs.go-version }}'
 
+      - name: 'RE: Build octocov and run as a action' # for checking re-upload artifact
+        uses: ./testdata/actions/coverage
+        env:
+          MACKEREL_API_KEY: ${{ secrets.MACKEREL_API_KEY }}
+          OCTOCOV_CUSTOM_METRICS_BENCHMARK_1: ./testdata/custom_metrics/benchmark_1.json
+          OCTOCOV_CUSTOM_METRICS_BENCHMARK_0: ./testdata/custom_metrics/benchmark_0.json
+          GOTOOLCHAIN: 'go${{ steps.setup-go.outputs.go-version }}'
+
       - name: Show rate limit
         run: |
           curl -sL -H "Authorization: token $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/rate_limit

--- a/datastore/artifact/artifact.go
+++ b/datastore/artifact/artifact.go
@@ -56,11 +56,11 @@ func (a *Artifact) Put(ctx context.Context, path string, content []byte) error {
 	if err != nil {
 		return err
 	}
-	runIDstr := os.Getenv("GITHUB_RUN_ID")
-	if runIDstr == "" {
-		return errors.New("GITHUB_RUN_ID is not set")
+	s := os.Getenv("GITHUB_RUN_ID")
+	if s == "" {
+		return errors.New("env GITHUB_RUN_ID is not set")
 	}
-	runID, err := strconv.ParseInt(runIDstr, 10, 64)
+	runID, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse GITHUB_RUN_ID: %w", err)
 	}


### PR DESCRIPTION
This pull request updates the artifact storage logic to improve how artifacts are uploaded and managed in GitHub Actions. The main changes involve passing explicit repository and workflow run information to artifact uploads and ensuring old artifacts with the same name are deleted before uploading new ones.

**Artifact upload improvements:**

* The `PutArtifact` method in `gh.go` now requires explicit `owner`, `repo`, and `runID` parameters, and deletes any existing artifact with the same name before uploading the new one. This prevents duplicate artifacts and ensures the latest artifact is always stored.
* The `Put` method in `artifact.go` is updated to parse the repository information and retrieve the `GITHUB_RUN_ID` from the environment, passing these values to `PutArtifact`. This ensures the artifact is associated with the correct workflow run and repository.

**Dependency and import changes:**

* Added imports for `os` and `strconv` in `artifact.go` to support environment variable access and string-to-integer conversion.