### PR TITLE
fix: enhance report content handling with key-based signature on summary

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -407,7 +407,7 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				if err := addReportContentToSummary(content); err != nil {
+				if err := addReportContentToSummary(content, r.Key()); err != nil {
 					return err
 				}
 				return nil

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -1,25 +1,49 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/k1LoW/repin"
 )
 
-func addReportContentToSummary(content string) error {
+func addReportContentToSummary(content, key string) error {
+	sig := generateSig(key)
 	p := os.Getenv("GITHUB_STEP_SUMMARY")
-	if _, err := os.Stat(p); err != nil {
-		return err
-	}
-	f, err := os.OpenFile(filepath.Clean(p), os.O_RDWR|os.O_CREATE|os.O_APPEND, os.ModePerm)
+	fi, err := os.Stat(p)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = f.Close() //nostyle:handlerrors
-	}()
-	if _, err := fmt.Fprintln(f, content); err != nil {
+	b, err := os.ReadFile(filepath.Clean(p))
+	if err != nil {
+		return err
+	}
+	current := string(b)
+	var rep string
+	if strings.Count(current, sig) < 2 {
+		rep = fmt.Sprintf("%s\n%s\n%s\n%s\n", current, sig, content, sig)
+	} else {
+		buf := new(bytes.Buffer)
+		if !strings.HasSuffix(current, "\n") {
+			current += "\n"
+		}
+		if _, err := repin.Replace(strings.NewReader(current), strings.NewReader(content), sig, sig, false, buf); err != nil {
+			return err
+		}
+		rep = buf.String()
+	}
+	if err := os.WriteFile(filepath.Clean(p), []byte(rep), fi.Mode()); err != nil {
 		return err
 	}
 	return nil
+}
+
+func generateSig(key string) string {
+	if key == "" {
+		return "<!-- octocov -->"
+	}
+	return fmt.Sprintf("<!-- octocov:%s -->", key)
 }


### PR DESCRIPTION
This pull request updates the logic for adding report content to the GitHub Actions summary file, allowing for targeted and idempotent updates using a signature based on a key. The changes ensure that content blocks can be uniquely identified and replaced if they already exist, rather than always appending new content.

Improvements to summary file handling:

* Updated `addReportContentToSummary` in `cmd/summary.go` to accept a `key` parameter, generate a unique signature, and replace existing content blocks with the same signature instead of always appending. This uses the `repin` library for block replacement and improves idempotency and clarity of the summary file.
* Modified the call to `addReportContentToSummary` in `cmd/root.go` to pass the appropriate `key` parameter, aligning with the new function signature and behavior.