### PR TITLE
doc: add an example of coverage paths normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,27 @@ jobs:
 
       - run: YOUR TEST HERE
 
+      # The generated coverage file may contain platform-dependent path (e.g. src/foo.ts on Mac/Ubuntu vs src\foo.ts on Windows)
+      # In that case, normalization is required so that octocov can merged the coverage correctly.
+      - name: Normalize coverage paths (repo-relative, POSIX)
+        working-directory: src-tauri
+        shell: bash # Works on Windows runner too.
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import os, re
+
+          p = Path('lcov.info')
+          data = p.read_text()
+
+          # unify separators (Windows -> POSIX)
+          data = data.replace('\\', '/')
+
+          # Add more normalization rules here if needed.
+
+          p.write_text(data)
+          PY
+
       - name: Upload coverage to workspace
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Because all of Ubuntu/Mac/Windows runners produce different coverage paths...
<img width="822" height="233" alt="image" src="https://github.com/user-attachments/assets/741d15c3-12a9-4966-ae17-22c007517c53" />

Normalization may be needed on other test matrix.
