### PR TITLE
fix: add required Scopes to credentials.DetectDefault for GCS and BigQuery

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -117,6 +117,7 @@ func New(ctx context.Context, u string, hints ...HintFunc) (Datastore, error) {
 		var client *storage.Client
 		if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON") != "" {
 			creds, err := credentials.DetectDefault(&credentials.DetectOptions{
+				Scopes:          []string{storage.ScopeFullControl},
 				CredentialsJSON: []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")),
 			})
 			if err != nil {
@@ -140,6 +141,7 @@ func New(ctx context.Context, u string, hints ...HintFunc) (Datastore, error) {
 		var client *bigquery.Client
 		if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON") != "" {
 			creds, err := credentials.DetectDefault(&credentials.DetectOptions{
+				Scopes:          []string{bigquery.Scope},
 				CredentialsJSON: []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")),
 			})
 			if err != nil {


### PR DESCRIPTION
ref: https://github.com/k1LoW/octocov/issues/613

This pull request updates the way Google Cloud credentials are initialized in the `datastore` package to explicitly set the required OAuth scopes for Storage and BigQuery clients. This ensures that the correct permissions are requested when using credentials provided via the `GOOGLE_APPLICATION_CREDENTIALS_JSON` environment variable.

Credential initialization improvements:

* Explicitly sets the `storage.ScopeFullControl` scope when creating a Storage client, ensuring the client has full access to Google Cloud Storage resources.
* Explicitly sets the `bigquery.Scope` scope when creating a BigQuery client, ensuring the client has the necessary permissions for BigQuery operations.