### PR TITLE
fix: support git worktree in GitRoot() and RootPath()

### DIFF
--- a/internal/path.go
+++ b/internal/path.go
@@ -15,6 +15,26 @@ var ConfigPaths = []string{
 	"octocov.yaml",
 }
 
+func isGitRoot(p string) bool {
+	dotGit := filepath.Join(p, ".git")
+	fi, err := os.Stat(dotGit)
+	if err != nil {
+		return false
+	}
+	if fi.IsDir() {
+		// Normal repo: .git/config exists
+		gitConfig := filepath.Join(dotGit, "config")
+		cfi, err := os.Stat(gitConfig)
+		return err == nil && !cfi.IsDir()
+	}
+	// Worktree: .git is a file starting with "gitdir:"
+	content, err := os.ReadFile(dotGit)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(string(content), "gitdir:")
+}
+
 func GitRoot(base string) (string, error) {
 	p, err := filepath.Abs(base)
 	if err != nil {
@@ -30,9 +50,7 @@ func GitRoot(base string) (string, error) {
 			continue
 		}
 
-		// Check for .git/config file
-		gitConfig := filepath.Join(p, ".git", "config")
-		if fi, err := os.Stat(gitConfig); err == nil && !fi.IsDir() {
+		if isGitRoot(p) {
 			return p, nil
 		}
 
@@ -44,7 +62,7 @@ func GitRoot(base string) (string, error) {
 	}
 
 	// Build error message with all checked paths
-	allPaths := []string{".git/config"}
+	allPaths := []string{".git"}
 	return "", fmt.Errorf("failed to traverse the root path (looking for %s): %s", strings.Join(allPaths, " or "), base)
 }
 
@@ -63,9 +81,7 @@ func RootPath(base string) (string, error) {
 			continue
 		}
 
-		// Check for .git/config file
-		gitConfig := filepath.Join(p, ".git", "config")
-		if fi, err := os.Stat(gitConfig); err == nil && !fi.IsDir() {
+		if isGitRoot(p) {
 			return p, nil
 		}
 
@@ -85,7 +101,7 @@ func RootPath(base string) (string, error) {
 	}
 
 	// Build error message with all checked paths
-	allPaths := append([]string{".git/config"}, ConfigPaths...)
+	allPaths := append([]string{".git"}, ConfigPaths...)
 	return "", fmt.Errorf("failed to traverse the root path (looking for %s): %s", strings.Join(allPaths, " or "), base)
 }
 
@@ -115,6 +131,10 @@ func CollectFiles(root string) ([]string, error) {
 			if _, skip := defaultSkipDirs[info.Name()]; skip {
 				return filepath.SkipDir
 			}
+			return nil
+		}
+		// Skip .git file (present in git worktrees instead of .git directory)
+		if info.Name() == ".git" {
 			return nil
 		}
 		files = append(files, path)

--- a/internal/path_test.go
+++ b/internal/path_test.go
@@ -8,6 +8,64 @@ import (
 	"testing"
 )
 
+func TestGitRoot(t *testing.T) {
+	t.Run("normal repo", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "a", "b"), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(filepath.Join(dir, ".git"), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".git", "config"), []byte("[core]"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := GitRoot(filepath.Join(dir, "a", "b"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != dir {
+			t.Errorf("got %v, want %v", got, dir)
+		}
+	})
+
+	t.Run("worktree", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "a", "b"), 0700); err != nil {
+			t.Fatal(err)
+		}
+		// Simulate worktree: .git is a file with "gitdir:" prefix
+		if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /some/main/.git/worktrees/wt1"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := GitRoot(filepath.Join(dir, "a", "b"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != dir {
+			t.Errorf("got %v, want %v", got, dir)
+		}
+	})
+
+	t.Run("invalid .git file", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "a"), 0700); err != nil {
+			t.Fatal(err)
+		}
+		// .git file without "gitdir:" prefix should not be recognized
+		if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("something else"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := GitRoot(filepath.Join(dir, "a"))
+		if err == nil {
+			t.Error("expected error for invalid .git file, got nil")
+		}
+	})
+}
+
 func TestRootPath(t *testing.T) {
 	t.Run("git config", func(t *testing.T) {
 		dir := t.TempDir()
@@ -151,6 +209,41 @@ func TestRootPath(t *testing.T) {
 		}
 	})
 
+	t.Run("worktree .git file", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "a", "b", "c"), 0700); err != nil {
+			t.Fatal(err)
+		}
+		// Simulate worktree: .git is a file with "gitdir:" prefix
+		if err := os.WriteFile(filepath.Join(dir, "a", "b", ".git"), []byte("gitdir: /some/main/.git/worktrees/wt1"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		tests := []struct {
+			base    string
+			wantErr bool
+		}{
+			{filepath.Join(dir, "a", "b", "c"), false},
+			{filepath.Join(dir, "a", "b"), false},
+			{filepath.Join(dir, "a"), true},
+		}
+		for _, tt := range tests {
+			got, err := RootPath(tt.base)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
+				}
+			} else {
+				if tt.wantErr {
+					t.Errorf("got %v\nwantErr %v", nil, tt.wantErr)
+				}
+				if want := filepath.Join(dir, "a", "b"); got != want {
+					t.Errorf("got %v\nwant %v", got, want)
+				}
+			}
+		}
+	})
+
 	t.Run("both files in same directory - git config takes precedence", func(t *testing.T) {
 		dir := t.TempDir()
 		if err := os.MkdirAll(filepath.Join(dir, "m", "n"), 0700); err != nil {
@@ -286,5 +379,27 @@ func TestCollectFiles_NestedSkipDirs(t *testing.T) {
 
 	if !slices.Equal(got, want) {
 		t.Errorf("CollectFiles() = %v, want %v", got, want)
+	}
+}
+
+func TestCollectFiles_WorktreeGitFile(t *testing.T) {
+	root := t.TempDir()
+
+	// Create a .git file (worktree) and a regular file
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: /some/main/.git/worktrees/wt1"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := CollectFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{filepath.Join(root, "main.go")}
+	if !slices.Equal(got, want) {
+		t.Errorf("CollectFiles() = %v, want %v (should not include .git file)", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- In git worktrees, `.git` is a file (containing `gitdir: /path/to/main/.git/worktrees/<name>`) instead of a directory. The previous implementation only checked for `.git/config`, causing `GitRoot()` and `RootPath()` to fail silently in worktree environments, which skipped path normalization introduced in PR #627.
- Add `isGitRoot()` helper that handles both normal repos (`.git/config` check) and worktrees (`.git` file with `gitdir:` prefix).
- Refactor `GitRoot()` and `RootPath()` to use the shared helper, and skip `.git` files in `CollectFiles()`.