### PR TITLE
Handle execution counts as uint64 and tolerate u64-wrapped LCOV counts

### DIFF
--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -150,7 +150,7 @@ func parseReportFile(f CloverReportFile) *FileCoverage {
 		}
 		sl := l.Num
 		el := l.Num
-		c := l.Count
+		c := toExecCount(l.Count)
 		fcov.Blocks = append(fcov.Blocks, &BlockCoverage{
 			Type:      TypeLOC,
 			StartLine: &sl,

--- a/coverage/cobertura.go
+++ b/coverage/cobertura.go
@@ -109,7 +109,7 @@ func (c *Cobertura) ParseReport(path string) (*Coverage, string, error) {
 			for _, l := range c.Lines.Line {
 				sl := l.Number
 				el := l.Number
-				c := l.Hits
+				c := toExecCount(l.Hits)
 				f = append(f, &BlockCoverage{
 					Type:      TypeLOC,
 					StartLine: &sl,

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -3,9 +3,12 @@ package coverage
 import (
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/goccy/go-json"
 	"github.com/zhangyunhao116/skipmap"
 )
 
@@ -149,14 +152,101 @@ func splitPath(p string) []string {
 
 type FileCoverages []*FileCoverage
 
+// ExecCount is a block execution count. It is uint64 internally so that
+// u64-wrapped counters emitted by llvm-based tools (e.g. cargo-llvm-cov when
+// profile counters race) survive parsing without truncation.
+//
+// In stored report.json the canonical field is "count_u64", which always
+// carries the raw uint64 value; uint64-aware readers prefer it and fall back
+// to "count" for reports written before its introduction. "count" is kept as
+// a compatibility field, clamped to MaxInt64 via ExecCount.MarshalJSON,
+// because binaries that decode counts into int (upstream octocov, older
+// versions of this fork) fail the whole report on out-of-int64 number
+// literals; they ignore the unknown "count_u64". The final migration step is
+// to stop emitting "count".
+type ExecCount uint64
+
+func (c ExecCount) MarshalJSON() ([]byte, error) {
+	if c > math.MaxInt64 {
+		c = math.MaxInt64
+	}
+	return []byte(strconv.FormatUint(uint64(c), 10)), nil
+}
+
+// satAdd returns a+b, saturating at MaxUint64 instead of wrapping.
+func satAdd(a, b ExecCount) ExecCount {
+	if s := a + b; s >= a {
+		return s
+	}
+	return math.MaxUint64
+}
+
+// toExecCount converts a count parsed from a signed representation, treating
+// negative values as 0.
+func toExecCount(c int) ExecCount {
+	if c < 0 {
+		return 0
+	}
+	return ExecCount(c)
+}
+
 type BlockCoverage struct {
-	Type      Type `json:"type"`
-	StartLine *int `json:"start_line,omitempty"`
-	StartCol  *int `json:"start_col,omitempty"`
-	EndLine   *int `json:"end_line,omitempty"`
-	EndCol    *int `json:"end_col,omitempty"`
-	NumStmt   *int `json:"num_stmt,omitempty"`
-	Count     *int `json:"count,omitempty"`
+	Type      Type       `json:"type"`
+	StartLine *int       `json:"start_line,omitempty"`
+	StartCol  *int       `json:"start_col,omitempty"`
+	EndLine   *int       `json:"end_line,omitempty"`
+	EndCol    *int       `json:"end_col,omitempty"`
+	NumStmt   *int       `json:"num_stmt,omitempty"`
+	Count     *ExecCount `json:"count,omitempty"`
+}
+
+// blockCoverageJSON mirrors BlockCoverage with the canonical "count_u64"
+// field alongside the clamped compatibility "count" (see ExecCount).
+type blockCoverageJSON struct {
+	Type      Type       `json:"type"`
+	StartLine *int       `json:"start_line,omitempty"`
+	StartCol  *int       `json:"start_col,omitempty"`
+	EndLine   *int       `json:"end_line,omitempty"`
+	EndCol    *int       `json:"end_col,omitempty"`
+	NumStmt   *int       `json:"num_stmt,omitempty"`
+	Count     *ExecCount `json:"count,omitempty"`
+	CountU64  *uint64    `json:"count_u64,omitempty"`
+}
+
+func (bc *BlockCoverage) MarshalJSON() ([]byte, error) {
+	a := blockCoverageJSON{
+		Type:      bc.Type,
+		StartLine: bc.StartLine,
+		StartCol:  bc.StartCol,
+		EndLine:   bc.EndLine,
+		EndCol:    bc.EndCol,
+		NumStmt:   bc.NumStmt,
+		Count:     bc.Count,
+	}
+	if bc.Count != nil {
+		raw := uint64(*bc.Count)
+		a.CountU64 = &raw
+	}
+	return json.Marshal(a)
+}
+
+func (bc *BlockCoverage) UnmarshalJSON(data []byte) error {
+	var a blockCoverageJSON
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	bc.Type = a.Type
+	bc.StartLine = a.StartLine
+	bc.StartCol = a.StartCol
+	bc.EndLine = a.EndLine
+	bc.EndCol = a.EndCol
+	bc.NumStmt = a.NumStmt
+	bc.Count = a.Count
+	if a.CountU64 != nil {
+		c := ExecCount(*a.CountU64)
+		bc.Count = &c
+	}
+	return nil
 }
 
 type BlockCoverages []*BlockCoverage
@@ -260,8 +350,8 @@ func (dc DiffFileCoverages) FuzzyFindByFile(file string) (*DiffFileCoverage, err
 	return nil, fmt.Errorf("file name not found: %s", file)
 }
 
-func (bc BlockCoverages) MaxCount() int { //nostyle:recvtype
-	counts := map[int]int{}
+func (bc BlockCoverages) MaxCount() ExecCount { //nostyle:recvtype
+	counts := map[int]ExecCount{}
 	for _, c := range bc {
 		sl := *c.StartLine
 		el := *c.EndLine
@@ -270,10 +360,10 @@ func (bc BlockCoverages) MaxCount() int { //nostyle:recvtype
 			if !ok {
 				counts[i] = 0
 			}
-			counts[i] += *c.Count
+			counts[i] = satAdd(counts[i], *c.Count)
 		}
 	}
-	max := 0
+	max := ExecCount(0)
 	for _, v := range counts {
 		if v > max {
 			max = v
@@ -289,12 +379,12 @@ const (
 
 type PosCoverage struct {
 	Pos   int
-	Count int
+	Count ExecCount
 }
 
 type PosCoverages []*PosCoverage
 
-func (pc PosCoverages) FindCountByPos(pos int) (int, error) { //nostyle:recvtype
+func (pc PosCoverages) FindCountByPos(pos int) (ExecCount, error) { //nostyle:recvtype
 	before := PosCoverages{}
 	after := PosCoverages{}
 	for _, c := range pc {
@@ -329,7 +419,7 @@ func (pc PosCoverages) FindCountByPos(pos int) (int, error) { //nostyle:recvtype
 
 type LineCoverage struct {
 	Line         int
-	Count        int
+	Count        ExecCount
 	PosCoverages PosCoverages
 }
 
@@ -359,23 +449,23 @@ func (lc LineCoverages) Covered() int { //nostyle:recvtype
 }
 
 func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype
-	m := skipmap.NewInt[*skipmap.IntMap[int]]()
+	m := skipmap.NewInt[*skipmap.IntMap[ExecCount]]()
 
 	for _, c := range bc {
 		sl := *c.StartLine
 		el := *c.EndLine
 		for i := sl; i <= el; i++ {
-			var mm *skipmap.IntMap[int]
+			var mm *skipmap.IntMap[ExecCount]
 			mm, ok := m.Load(i)
 			if !ok {
-				mm = skipmap.NewInt[int]()
+				mm = skipmap.NewInt[ExecCount]()
 			}
 			m.Store(i, mm)
 
 			if c.Type == TypeLOC || (sl < i && i < el) {
 				// TypeLOC or TypeStmt
-				mm.Range(func(key int, v int) bool {
-					mm.Store(key, v+*c.Count)
+				mm.Range(func(key int, v ExecCount) bool {
+					mm.Store(key, satAdd(v, *c.Count))
 					return true
 				})
 				if _, ok := mm.Load(startPos); !ok {
@@ -388,15 +478,15 @@ func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype
 			}
 
 			// TypeStmt
-			startCount := 0
-			endCount := 0
+			startCount := ExecCount(0)
+			endCount := ExecCount(0)
 			startTo := startPos
 			endFrom := endPos
 			var (
 				pos    []int
-				counts []int
+				counts []ExecCount
 			)
-			mm.Range(func(key int, v int) bool {
+			mm.Range(func(key int, v ExecCount) bool {
 				pos = append(pos, key)
 				counts = append(counts, v)
 				return true
@@ -414,9 +504,9 @@ func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype
 
 			switch {
 			case i == sl && i != el:
-				mm.Range(func(key int, v int) bool {
+				mm.Range(func(key int, v ExecCount) bool {
 					if key >= *c.StartCol {
-						mm.Store(key, v+*c.Count)
+						mm.Store(key, satAdd(v, *c.Count))
 					}
 					return true
 				})
@@ -430,21 +520,21 @@ func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype
 				for j := *c.StartCol; j <= *c.EndCol; j++ {
 					v, ok := mm.Load(j)
 					if ok {
-						mm.Store(j, v+*c.Count)
+						mm.Store(j, satAdd(v, *c.Count))
 					} else {
 						if j <= startTo {
-							mm.Store(j, startCount+*c.Count)
+							mm.Store(j, satAdd(startCount, *c.Count))
 						} else if endFrom <= j {
-							mm.Store(j, endCount+*c.Count)
+							mm.Store(j, satAdd(endCount, *c.Count))
 						} else {
 							mm.Store(j, *c.Count)
 						}
 					}
 				}
 			case i != sl && i == el:
-				mm.Range(func(key int, v int) bool {
+				mm.Range(func(key int, v ExecCount) bool {
 					if key <= *c.EndCol {
-						mm.Store(key, v+*c.Count)
+						mm.Store(key, satAdd(v, *c.Count))
 					}
 					return true
 				})
@@ -459,13 +549,13 @@ func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype
 	}
 
 	lcs := LineCoverages{}
-	m.Range(func(line int, mm *skipmap.IntMap[int]) bool {
+	m.Range(func(line int, mm *skipmap.IntMap[ExecCount]) bool {
 		lc := &LineCoverage{
 			Line:         line,
 			Count:        0,
 			PosCoverages: PosCoverages{},
 		}
-		mm.Range(func(pos int, c int) bool {
+		mm.Range(func(pos int, c ExecCount) bool {
 			lc.PosCoverages = append(lc.PosCoverages, &PosCoverage{
 				Pos:   pos,
 				Count: c,

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -166,7 +166,7 @@ type FileCoverages []*FileCoverage
 // to stop emitting "count".
 type ExecCount uint64
 
-func (c ExecCount) MarshalJSON() ([]byte, error) {
+func (c ExecCount) MarshalJSON() ([]byte, error) { //nostyle:recvtype
 	if c > math.MaxInt64 {
 		c = math.MaxInt64
 	}

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -93,7 +93,7 @@ func TestCompare(t *testing.T) {
 func TestMaxCount(t *testing.T) {
 	tests := []struct {
 		blocks BlockCoverages
-		want   int
+		want   ExecCount
 	}{
 		{
 			BlockCoverages{
@@ -407,11 +407,12 @@ func TestDiffFileCoveragesFuzzyFindByFile(t *testing.T) {
 }
 
 func newBlockCoverage(t Type, sl, sc, el, ec, ns, c int) *BlockCoverage {
+	cc := toExecCount(c)
 	bc := &BlockCoverage{
 		Type:      t,
 		StartLine: &sl,
 		EndLine:   &el,
-		Count:     &c,
+		Count:     &cc,
 	}
 	if sc >= 0 {
 		bc.StartCol = &sc

--- a/coverage/exec_count_test.go
+++ b/coverage/exec_count_test.go
@@ -1,0 +1,95 @@
+package coverage
+
+import (
+	"math"
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+func TestExecCountMarshalClampsToMaxInt64(t *testing.T) {
+	// Transitional: stored report.json is read by binaries that decode
+	// counts into int, so "count" beyond MaxInt64 must not be emitted;
+	// the raw value goes to "count_u64" instead (ignored by int readers).
+	c := ExecCount(math.MaxUint64 - 4)
+	bc := &BlockCoverage{
+		Type:  TypeLOC,
+		Count: &c,
+	}
+	b, err := json.Marshal(bc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded struct {
+		Count *int `json:"count"`
+	}
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("marshaled count is not decodable as int: %v\n%s", err, b)
+	}
+	if want := math.MaxInt64; *decoded.Count != want {
+		t.Errorf("got %v\nwant %v", *decoded.Count, want)
+	}
+}
+
+func TestExecCountRoundTripsViaCountU64(t *testing.T) {
+	// uint64-aware readers restore the unclamped value from "count_u64".
+	c := ExecCount(math.MaxUint64 - 4)
+	bc := &BlockCoverage{
+		Type:  TypeLOC,
+		Count: &c,
+	}
+	b, err := json.Marshal(bc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got BlockCoverage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if *got.Count != c {
+		t.Errorf("got %v\nwant %v", *got.Count, c)
+	}
+}
+
+func TestExecCountMarshalAlwaysEmitsCountU64(t *testing.T) {
+	// count_u64 is the canonical field and is emitted for every count, so
+	// the schema does not change shape depending on the value.
+	c := ExecCount(42)
+	bc := &BlockCoverage{
+		Type:  TypeLOC,
+		Count: &c,
+	}
+	b, err := json.Marshal(bc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `{"type":"loc","count":42,"count_u64":42}`; string(b) != want {
+		t.Errorf("got %s\nwant %s", b, want)
+	}
+}
+
+func TestExecCountUnmarshal(t *testing.T) {
+	var bc BlockCoverage
+	if err := json.Unmarshal([]byte(`{"type":"loc","count":42}`), &bc); err != nil {
+		t.Fatal(err)
+	}
+	if want := ExecCount(42); *bc.Count != want {
+		t.Errorf("got %v\nwant %v", *bc.Count, want)
+	}
+}
+
+func TestSatAdd(t *testing.T) {
+	tests := []struct {
+		a, b, want ExecCount
+	}{
+		{1, 2, 3},
+		{math.MaxUint64, 1, math.MaxUint64},
+		{math.MaxUint64 - 4, 10, math.MaxUint64},
+		{0, math.MaxUint64, math.MaxUint64},
+	}
+	for _, tt := range tests {
+		if got := satAdd(tt.a, tt.b); got != tt.want {
+			t.Errorf("satAdd(%v, %v) = %v\nwant %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/coverage/gocover.go
+++ b/coverage/gocover.go
@@ -44,7 +44,7 @@ func (g *Gocover) ParseReport(path string) (*Coverage, string, error) {
 			el := b.EndLine
 			ec := b.EndCol
 			ns := b.NumStmt
-			c := b.Count
+			c := toExecCount(b.Count)
 			fcov.Blocks = append(fcov.Blocks, &BlockCoverage{
 				Type:      TypeStmt,
 				StartLine: &sl,

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -106,7 +106,7 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 			for _, l := range s.Line {
 				sl := l.Nr
 				el := l.Nr
-				c := 0
+				c := ExecCount(0)
 				if l.Ci > 0 {
 					c = 1
 				}

--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -81,19 +81,26 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 				_ = r.Close() //nostyle:handlerrors
 				return nil, "", err
 			}
-			count, err := strconv.Atoi(nums[1])
-			if err != nil {
+			// Parse as uint64: llvm-cov can emit u64-wrapped (negative)
+			// execution counts when profile counters race (e.g. a thread
+			// still running at process exit), so counts up to MaxUint64 are
+			// valid input. On ErrRange (> MaxUint64) ParseUint has already
+			// saturated the value; accept it instead of rejecting the whole
+			// report over one corrupt counter.
+			count, err := strconv.ParseUint(nums[1], 10, 64)
+			if err != nil && !errors.Is(err, strconv.ErrRange) {
 				_ = r.Close() //nostyle:handlerrors
 				return nil, "", err
 			}
 			if count > 0 {
 				covered += 1
 			}
+			c := ExecCount(count)
 			blocks = append(blocks, &BlockCoverage{
 				Type:      TypeLOC,
 				StartLine: &line,
 				EndLine:   &line,
-				Count:     &count,
+				Count:     &c,
 			})
 		default:
 			// not implemented

--- a/coverage/lcov_test.go
+++ b/coverage/lcov_test.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -41,6 +42,40 @@ func TestLcov(t *testing.T) {
 		if got := f.Covered; got != covered {
 			t.Errorf("got %v\nwant %v", got, covered)
 		}
+	}
+}
+
+func TestLcovAcceptsU64WrappedCounts(t *testing.T) {
+	// llvm-cov (e.g. cargo-llvm-cov) can emit u64-wrapped negative execution
+	// counts when profile counters race; one such line must not reject the
+	// whole report, and the raw u64 value must survive parsing.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lcov.info")
+	content := `TN:
+SF:src/cache.rs
+DA:1,1
+DA:2,18446744073709551611
+DA:3,0
+LF:3
+LH:2
+end_of_record
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewLcov().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 3; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	// The wrapped counter still counts as executed.
+	if want := 2; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+	if want := ExecCount(18446744073709551611); *got.Files[0].Blocks[1].Count != want {
+		t.Errorf("got %v\nwant %v", *got.Files[0].Blocks[1].Count, want)
 	}
 }
 

--- a/coverage/printer.go
+++ b/coverage/printer.go
@@ -39,7 +39,7 @@ func (p *Printer) Print(src io.Reader, dest io.Writer) error {
 	c := bytes.Count(b, []byte{'\n'})
 
 	w := len(strconv.Itoa(c))
-	w2 := len(strconv.Itoa(p.fc.Blocks.MaxCount()))
+	w2 := len(strconv.FormatUint(uint64(p.fc.Blocks.MaxCount()), 10))
 
 	e, err := guess.EncodingBytes(b)
 	if err != nil {
@@ -75,7 +75,7 @@ const (
 	posRed   = "r"
 )
 
-func lineCovered(lcnt int, lc *LineCoverage) (int, []string) {
+func lineCovered(lcnt int, lc *LineCoverage) (ExecCount, []string) {
 	l := make([]string, lcnt)
 	if lc == nil {
 		return 0, l

--- a/coverage/simplecov.go
+++ b/coverage/simplecov.go
@@ -83,7 +83,7 @@ func (s *Simplecov) ParseReport(path string) (*Coverage, string, error) {
 				ll := l + 1
 				switch v := c.(type) {
 				case float64:
-					count := int(v)
+					count := toExecCount(int(v))
 					fcov.Blocks = append(fcov.Blocks, &BlockCoverage{
 						Type:      TypeLOC,
 						StartLine: &ll,

--- a/report/report.go
+++ b/report/report.go
@@ -764,42 +764,42 @@ func challengeParseReport(path string) (*coverage.Coverage, string, error) {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as Go coverage: %s", err)
-		errs = append(errs, fmt.Errorf("Go coverage: %w", err))
+		errs = append(errs, fmt.Errorf("go coverage: %w", err))
 	}
 	// lcov
 	if cov, rp, err := coverage.NewLcov().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as LCOV: %s", err)
-		errs = append(errs, fmt.Errorf("LCOV: %w", err))
+		errs = append(errs, fmt.Errorf("lcov: %w", err))
 	}
 	// simplecov
 	if cov, rp, err := coverage.NewSimplecov().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as SimpleCov: %s", err)
-		errs = append(errs, fmt.Errorf("SimpleCov: %w", err))
+		errs = append(errs, fmt.Errorf("simpleCov: %w", err))
 	}
 	// clover
 	if cov, rp, err := coverage.NewClover().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as Clover: %s", err)
-		errs = append(errs, fmt.Errorf("Clover: %w", err))
+		errs = append(errs, fmt.Errorf("clover: %w", err))
 	}
 	// cobertura
 	if cov, rp, err := coverage.NewCobertura().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as Cobertura: %s", err)
-		errs = append(errs, fmt.Errorf("Cobertura: %w", err))
+		errs = append(errs, fmt.Errorf("cobertura: %w", err))
 	}
 	// jacoco
 	if cov, rp, err := coverage.NewJacoco().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as JaCoCo: %s", err)
-		errs = append(errs, fmt.Errorf("JaCoCo: %w", err))
+		errs = append(errs, fmt.Errorf("jacoco: %w", err))
 	}
 
 	msg := fmt.Sprintf("parsable coverage report not found: %s", path)

--- a/report/report.go
+++ b/report/report.go
@@ -758,47 +758,54 @@ func mergeExecutionTimes(steps []gh.Step) time.Duration {
 }
 
 func challengeParseReport(path string) (*coverage.Coverage, string, error) {
+	var errs []error
 	// gocover
 	if cov, rp, err := coverage.NewGocover().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as Go coverage: %s", err)
+		errs = append(errs, fmt.Errorf("Go coverage: %w", err))
 	}
 	// lcov
 	if cov, rp, err := coverage.NewLcov().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as LCOV: %s", err)
+		errs = append(errs, fmt.Errorf("LCOV: %w", err))
 	}
 	// simplecov
 	if cov, rp, err := coverage.NewSimplecov().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as SimpleCov: %s", err)
+		errs = append(errs, fmt.Errorf("SimpleCov: %w", err))
 	}
 	// clover
 	if cov, rp, err := coverage.NewClover().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as Clover: %s", err)
+		errs = append(errs, fmt.Errorf("Clover: %w", err))
 	}
 	// cobertura
 	if cov, rp, err := coverage.NewCobertura().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as Cobertura: %s", err)
+		errs = append(errs, fmt.Errorf("Cobertura: %w", err))
 	}
 	// jacoco
 	if cov, rp, err := coverage.NewJacoco().ParseReport(path); err == nil {
 		return cov, rp, nil
 	} else {
 		log.Printf("parse as JaCoCo: %s", err)
+		errs = append(errs, fmt.Errorf("JaCoCo: %w", err))
 	}
 
 	msg := fmt.Sprintf("parsable coverage report not found: %s", path)
 	log.Println(msg)
 
-	return nil, "", errors.New(msg)
+	return nil, "", fmt.Errorf("%s: %w", msg, errors.Join(errs...))
 }
 
 // floor1 round down to one decimal place.


### PR DESCRIPTION
llvm-cov (e.g. cargo-llvm-cov) can emit u64-wrapped negative execution counts like DA:174,18446744073709551611 when profile counters race — for instance when an instrumented process exits while a background thread is still running. One such line previously failed the whole LCOV report with strconv's ErrRange, which surfaced as "parsable coverage report not found" and failed the job even though the report is otherwise fine.

Treat execution counts as uint64 end to end:

- Introduce ExecCount (uint64) as the type of BlockCoverage.Count and everything downstream (PosCoverage, LineCoverage, MaxCount), so the full u64 range parses and survives unmangled. LCOV now parses counts with ParseUint, tolerating only ErrRange (> MaxUint64) by accepting the saturated value.
- Sum sites (MaxCount, ToLineCoverages) use saturating addition so near-MaxUint64 counters cannot wrap back to small values.
- In stored report.json the canonical field is "count_u64", which always carries the raw uint64 value; uint64-aware readers prefer it and fall back to "count" for reports written before its introduction. "count" remains as a compatibility field clamped to MaxInt64, because binaries that decode counts into int (upstream octocov, older versions of this fork) fail the whole report on out-of-int64 number literals; they ignore the unknown "count_u64". The final migration step is simply to stop emitting "count".

Also include each format parser's error in the final "parsable coverage report not found" error (via errors.Join) — the underlying cause ("value out of range") was previously visible nowhere, which makes this class of failure look like a missing file.