### PR TITLE
fix: insert a blank line before the octocov marker in PR body embed

### DIFF
--- a/gh/gh.go
+++ b/gh/gh.go
@@ -280,19 +280,9 @@ func (g *Gh) ReplaceInsertToBody(ctx context.Context, owner, repo string, number
 	if err != nil {
 		return err
 	}
-	current := pr.GetBody()
-	var rep string
-	if strings.Count(current, sig) < 2 {
-		rep = fmt.Sprintf("%s\n%s\n%s\n%s\n", current, sig, content, sig)
-	} else {
-		buf := new(bytes.Buffer)
-		if !strings.HasSuffix(current, "\n") {
-			current += "\n"
-		}
-		if _, err := repin.Replace(strings.NewReader(current), strings.NewReader(content), sig, sig, false, buf); err != nil {
-			return err
-		}
-		rep = buf.String()
+	rep, err := insertToBody(pr.GetBody(), content, sig)
+	if err != nil {
+		return err
 	}
 	if _, _, err := g.client.PullRequests.Edit(ctx, owner, repo, number, &github.PullRequest{
 		Body: &rep,
@@ -919,4 +909,37 @@ func generateSig(key string) string {
 		return "<!-- octocov -->"
 	}
 	return fmt.Sprintf("<!-- octocov:%s -->", key)
+}
+
+// insertToBody embeds content delimited by sig into current, replacing the previously
+// embedded content when current already holds a pair of sig.
+func insertToBody(current, content, sig string) (string, error) {
+	if strings.Count(current, sig) < 2 {
+		return fmt.Sprintf("%s%s\n%s\n%s\n", terminateBeforeSig(current), sig, content, sig), nil
+	}
+	// repin.Replace copies everything preceding the opening sig verbatim, so bodies embedded
+	// by earlier versions keep their missing blank line unless it is restored here.
+	if i := strings.Index(current, sig); i > 0 {
+		current = terminateBeforeSig(current[:i]) + current[i:]
+	}
+	if !strings.HasSuffix(current, "\n") {
+		current += "\n"
+	}
+	buf := new(bytes.Buffer)
+	if _, err := repin.Replace(strings.NewReader(current), strings.NewReader(content), sig, sig, false, buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// terminateBeforeSig closes before with a blank line so that the sig following it starts a
+// fresh Markdown block. GitHub parses an unterminated HTML block, such as a badge <a> tag
+// appended by another GitHub App, as raw HTML up to the next blank line, which would
+// otherwise swallow the report heading and table and render them as literal text.
+func terminateBeforeSig(before string) string {
+	before = strings.TrimRight(before, "\r\n")
+	if before == "" {
+		return ""
+	}
+	return before + "\n\n"
 }

--- a/gh/gh_test.go
+++ b/gh/gh_test.go
@@ -170,6 +170,82 @@ func TestGenerateSig(t *testing.T) {
 		}
 	}
 }
+
+func TestInsertToBody(t *testing.T) {
+	const content = "## Code Metrics Report\n| | main | PR |\n|-|-|-|"
+	tests := []struct {
+		name    string
+		current string
+		sig     string
+		want    string
+	}{
+		{
+			"empty body",
+			"",
+			"<!-- octocov -->",
+			"<!-- octocov -->\n" + content + "\n<!-- octocov -->\n",
+		},
+		{
+			"body without trailing newline",
+			"Some PR description.",
+			"<!-- octocov -->",
+			"Some PR description.\n\n<!-- octocov -->\n" + content + "\n<!-- octocov -->\n",
+		},
+		{
+			"body ending with an unterminated HTML block",
+			"Some PR description.\n\n<a href=\"https://example.com\">\n  <img src=\"https://example.com/badge.svg\" alt=\"badge\">\n</a>\n",
+			"<!-- octocov -->",
+			"Some PR description.\n\n<a href=\"https://example.com\">\n  <img src=\"https://example.com/badge.svg\" alt=\"badge\">\n</a>\n\n<!-- octocov -->\n" + content + "\n<!-- octocov -->\n",
+		},
+		{
+			"body already ending with a blank line",
+			"Some PR description.\n\n",
+			"<!-- octocov -->",
+			"Some PR description.\n\n<!-- octocov -->\n" + content + "\n<!-- octocov -->\n",
+		},
+		{
+			"body with CRLF line endings",
+			"Some PR description.\r\n",
+			"<!-- octocov -->",
+			"Some PR description.\n\n<!-- octocov -->\n" + content + "\n<!-- octocov -->\n",
+		},
+		{
+			"body with keyed sig",
+			"Some PR description.",
+			"<!-- octocov:foo -->",
+			"Some PR description.\n\n<!-- octocov:foo -->\n" + content + "\n<!-- octocov:foo -->\n",
+		},
+		{
+			"re-embed replaces the previously embedded content",
+			"Some PR description.\n\n<!-- octocov -->\n## Old Report\n<!-- octocov -->\n",
+			"<!-- octocov -->",
+			"Some PR description.\n\n<!-- octocov -->\n" + content + "\n<!-- octocov -->\n",
+		},
+		{
+			"re-embed restores the blank line missing from an already embedded body",
+			"Some PR description.\n\n<a href=\"https://example.com\">\n</a>\n<!-- octocov -->\n## Old Report\n<!-- octocov -->\n",
+			"<!-- octocov -->",
+			"Some PR description.\n\n<a href=\"https://example.com\">\n</a>\n\n<!-- octocov -->\n" + content + "\n<!-- octocov -->\n",
+		},
+		{
+			"body consisting only of the embedded content",
+			"<!-- octocov -->\n## Old Report\n<!-- octocov -->\n",
+			"<!-- octocov -->",
+			"<!-- octocov -->\n" + content + "\n<!-- octocov -->\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := insertToBody(tt.current, content, tt.sig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(got, tt.want, nil); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
 func mockedGh(t *testing.T) *Gh {
 	t.Setenv("GITHUB_TOKEN", "dummy")
 	mockedHTTPClient := mock.NewMockedHTTPClient( //nostyle:funcfmt


### PR DESCRIPTION
## Summary

- On the first `body:` insertion, `ReplaceInsertToBody()` joined the existing PR body and the `<!-- octocov -->` marker with a single `\n`. When the body ended with an unterminated HTML block (a CommonMark HTML block, type 7), GitHub kept parsing raw HTML up to the next blank line and swallowed the injected `## Code Metrics Report` heading and summary table, rendering them as literal text.
- Terminate the preceding body with a blank line before the marker. A blank line is idempotent in Markdown, so bodies that already have proper separation are unaffected, and `TrimRight` on `"\r\n"` covers bodies returned with CRLF line endings.
- Also normalize the re-embed path. `repin.Replace()` copies everything preceding the opening marker verbatim, so PR bodies embedded by earlier versions would otherwise keep their missing blank line on every subsequent run.
- Extract the body composition into `insertToBody()` so both paths are covered by unit tests without a GitHub client.

This only affected `body:` embedding. `comment:` mode is fine because each comment is a standalone document.

## Reproduction

A PR body ending with an HTML block and no trailing blank line, e.g. a review badge added by a third-party GitHub App:

```md
Some PR description.

<a href="https://example.com">
  <img src="https://example.com/badge.svg" alt="badge">
</a>
```

Rendering the previous output through `POST /markdown` with `mode: gfm` returns the heading and table untouched as literal text:

```html
<p>Some PR description.</p>
<a href="https://example.com" rel="nofollow">
  <img src="..." alt="badge">
</a>

## Code Metrics Report
| | main | PR | +/- |
```

With the blank line restored, the same input renders as expected:

```html
<h2>Code Metrics Report</h2>
<markdown-accessiblity-table><table role="table">
```

## Test plan

- [x] `go test ./gh/ -run TestInsertToBody -v` passes. Covers empty body, body without a trailing newline, body ending with an unterminated HTML block, body already ending with a blank line, CRLF line endings, keyed sig, re-embed, and re-embed of an already broken body.
- [x] `go test ./...` passes.
- [x] `golangci-lint run` and `gostyle` report no issues.

Closes #695