### PR TITLE
fix: paginate ListWorkflowJobs so testExecutionTime.steps covers every job

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,8 @@ testExecutionTime:
     - Run slow test
 ```
 
+Steps with a matching name are collected from **every job in the workflow run**, and their execution times are merged (overlapping time ranges are counted only once). This makes it possible to measure the total test execution time when the tests are split across multiple jobs, for example by a GitHub Actions matrix. See [Merging reports from multiple GitHub Action jobs](#merging-reports-from-multiple-github-action-jobs).
+
 If not specified, the step where the coverage report file is generated is used as the measurement target.
 
 ### `testExecutionTime.badge`

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -488,9 +488,15 @@ L:
 				}
 			}
 		}
-		if max == len(steps) {
+		// Keep retrying while nothing matched. The step may belong to a job that
+		// has not started yet, and returning the empty result as a success would
+		// silently measure a test execution time of zero.
+		if max > 0 && max == len(steps) {
 			return steps, nil
 		}
+	}
+	if max == 0 {
+		return nil, fmt.Errorf("no step named %s exists in the workflow run", name)
 	}
 	if max < len(steps) || len(steps) == 0 {
 		return nil, fmt.Errorf("could not get step times: %s", name)

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -500,7 +500,7 @@ L:
 	}
 	// A pass that collected every match returns inside the loop, so getting here
 	// means the backoff ran out while a matching step was still incomplete.
-	return nil, fmt.Errorf("could not get step times: %s", name)
+	return nil, fmt.Errorf("step named %q did not complete in time", name)
 }
 
 func (g *Gh) PutComment(ctx context.Context, owner, repo string, n int, comment, key string) error {

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -496,7 +496,7 @@ L:
 		}
 	}
 	if max == 0 {
-		return nil, fmt.Errorf("no step named %s exists in the workflow run", name)
+		return nil, fmt.Errorf("could not find any step named %q in the workflow run", name)
 	}
 	if max < len(steps) || len(steps) == 0 {
 		return nil, fmt.Errorf("could not get step times: %s", name)

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -498,10 +498,9 @@ L:
 	if max == 0 {
 		return nil, fmt.Errorf("could not find any step named %q in the workflow run", name)
 	}
-	if max < len(steps) || len(steps) == 0 {
-		return nil, fmt.Errorf("could not get step times: %s", name)
-	}
-	return steps, nil
+	// A pass that collected every match returns inside the loop, so getting here
+	// means the backoff ran out while a matching step was still incomplete.
+	return nil, fmt.Errorf("could not get step times: %s", name)
 }
 
 func (g *Gh) PutComment(ctx context.Context, owner, repo string, n int, comment, key string) error {

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -195,14 +195,14 @@ func (g *Gh) DetectCurrentJobID(ctx context.Context, owner, repo string) (int64,
 	)
 	b := p.Start(ctx)
 	for backoff.Continue(b) {
-		jobs, _, err := g.client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, &github.ListWorkflowJobsOptions{})
+		jobs, err := g.listWorkflowJobs(ctx, owner, repo, runID)
 		if err != nil {
 			return 0, err
 		}
-		if len(jobs.Jobs) == 1 {
-			return jobs.Jobs[0].GetID(), nil
+		if len(jobs) == 1 {
+			return jobs[0].GetID(), nil
 		}
-		for _, j := range jobs.Jobs {
+		for _, j := range jobs {
 			if j.GetName() == os.Getenv("GITHUB_JOB") {
 				return j.GetID(), nil
 			}
@@ -465,11 +465,11 @@ func (g *Gh) FetchStepsByName(ctx context.Context, owner, repo string, name stri
 L:
 	for backoff.Continue(b) {
 		max = 0
-		jobs, _, err := g.client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, &github.ListWorkflowJobsOptions{})
+		jobs, err := g.listWorkflowJobs(ctx, owner, repo, runID)
 		if err != nil {
 			return nil, err
 		}
-		for _, j := range jobs.Jobs {
+		for _, j := range jobs {
 			log.Printf("search job: %d", j.GetID()) //nolint:gosec // format string uses %d, no injection risk
 			l := len(j.Steps)
 			for i, s := range j.Steps {
@@ -639,6 +639,27 @@ func (g *Gh) IsPrivate(ctx context.Context, owner, repo string) (bool, error) {
 		return false, err
 	}
 	return r.GetPrivate(), nil
+}
+
+// listWorkflowJobs returns every job of the workflow run, following pagination.
+// The API returns 30 jobs per page by default, so a run with a large matrix
+// would otherwise be silently truncated.
+func (g *Gh) listWorkflowJobs(ctx context.Context, owner, repo string, runID int64) ([]*github.WorkflowJob, error) {
+	opts := &github.ListWorkflowJobsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	var jobs []*github.WorkflowJob
+	for {
+		js, res, err := g.client.Actions.ListWorkflowJobs(ctx, owner, repo, runID, opts)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, js.Jobs...)
+		if res.NextPage == 0 {
+			return jobs, nil
+		}
+		opts.Page = res.NextPage
+	}
 }
 
 type minimizeCommentMutation struct {

--- a/gh/gh_test.go
+++ b/gh/gh_test.go
@@ -429,6 +429,53 @@ func TestDetectCurrentPullRequestNumberSkipsForkPR(t *testing.T) {
 	}
 }
 
+func TestListWorkflowJobs(t *testing.T) {
+	// Every job of the run must be returned even when the run has more jobs
+	// than fit in a single page of the API response.
+	t.Setenv("GITHUB_TOKEN", "dummy")
+
+	mockedHTTPClient := mock.NewMockedHTTPClient( //nostyle:funcfmt
+		mock.WithRequestMatchPages( //nostyle:funcfmt
+			mock.GetReposActionsRunsJobsByOwnerByRepoByRunId,
+			github.Jobs{
+				TotalCount: github.Int(3),
+				Jobs: []*github.WorkflowJob{
+					{ID: github.Int64(1), Name: github.String("test (1)")},
+					{ID: github.Int64(2), Name: github.String("test (2)")},
+				},
+			},
+			github.Jobs{
+				TotalCount: github.Int(3),
+				Jobs: []*github.WorkflowJob{
+					{ID: github.Int64(3), Name: github.String("test (3)")},
+				},
+			},
+		),
+	)
+	client, err := factory.NewGithubClient(factory.HTTPClient(mockedHTTPClient), factory.Timeout(10*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	g.SetClient(client)
+
+	jobs, err := g.listWorkflowJobs(context.TODO(), "owner", "repo", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []int64
+	for _, j := range jobs {
+		got = append(got, j.GetID())
+	}
+	want := []int64{1, 2, 3}
+	if diff := cmp.Diff(got, want, nil); diff != "" {
+		t.Error(diff)
+	}
+}
+
 func TestIsSameRepo(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/gh/gh_test.go
+++ b/gh/gh_test.go
@@ -476,6 +476,83 @@ func TestListWorkflowJobs(t *testing.T) {
 	}
 }
 
+func TestFetchStepsByNameErrors(t *testing.T) {
+	// Exhausting the retries must fail loudly. Reporting no steps as a success
+	// would measure a test execution time of zero for a step that was merely
+	// misspelled or still running.
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		jobs    []*github.WorkflowJob
+		step    string
+		wantErr string
+	}{
+		{
+			name: "no job has a step with the given name",
+			jobs: []*github.WorkflowJob{
+				{ID: github.Int64(1), Steps: []*github.TaskStep{
+					{
+						Name:        github.String("Run test"),
+						StartedAt:   &github.Timestamp{Time: base},
+						CompletedAt: &github.Timestamp{Time: base.Add(time.Minute)},
+					},
+				}},
+			},
+			step:    "Run slow test",
+			wantErr: `could not find any step named "Run slow test" in the workflow run`,
+		},
+		{
+			name: "the named step never completes",
+			jobs: []*github.WorkflowJob{
+				{ID: github.Int64(1), Steps: []*github.TaskStep{
+					{
+						Name:      github.String("Run test"),
+						StartedAt: &github.Timestamp{Time: base},
+					},
+				}},
+			},
+			step:    "Run test",
+			wantErr: `step named "Run test" did not complete in time`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", "dummy")
+			t.Setenv("GITHUB_RUN_ID", "1")
+
+			mockedHTTPClient := mock.NewMockedHTTPClient( //nostyle:funcfmt
+				mock.WithRequestMatch( //nostyle:funcfmt
+					mock.GetReposActionsRunsJobsByOwnerByRepoByRunId,
+					github.Jobs{TotalCount: github.Int(len(tt.jobs)), Jobs: tt.jobs},
+				),
+			)
+			client, err := factory.NewGithubClient(factory.HTTPClient(mockedHTTPClient), factory.Timeout(10*time.Second))
+			if err != nil {
+				t.Fatal(err)
+			}
+			g, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			g.SetClient(client)
+
+			// The retry window spans tens of seconds, so end it through the context
+			// instead of waiting it out.
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			got, err := g.FetchStepsByName(ctx, "owner", "repo", tt.step)
+			if err == nil {
+				t.Fatalf("want err, got steps: %v", got)
+			}
+			if err.Error() != tt.wantErr {
+				t.Errorf("got %v\nwant %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestIsSameRepo(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Collecting the named step from every job of the workflow run and merging the overlapping ranges has been the behavior of `testExecutionTime.steps:` since #28, but the configuration reference never said so. In #697 a contributor read `steps:` as searching only the job octocov itself runs in, and proposed a new `testExecutionTime.jobs:` option to cross the job boundary, work that turned out to be unnecessary. Document the existing behavior where it is looked up, and link it to the merging example.

While documenting it, the claim turned out not to hold for large runs. `DetectCurrentJobID` and `FetchStepsByName` both queried the run's jobs with default options, and the API returns 30 jobs per page, so a run whose matrix expands beyond that silently lost the tail. Steps named in `steps:` were left unmeasured, and the job octocov itself runs in could go undetected. Both now go through a shared `listWorkflowJobs` helper that sets `PerPage: 100` and follows `NextPage`.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./gh/` passes
- [x] `golangci-lint run ./gh/...` reports no issues

Ref: #697