### PR TITLE
fix: measure patch coverage before the report is shrunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,13 @@ diff is too large for the API to include, and for files beyond the limit of the 
 default branch outside of a pull request). Such files lower neither the covered lines nor the total
 lines of `patch`.
 
+The file coverage table that octocov reports for a pull request (in the pull request comment, the
+job summary, and the pull request body) includes a **Patch Coverage** column, and its heading shows
+the overall patch coverage. This needs no configuration and is independent of
+`coverage.acceptable:`, so the column appears even when the condition does not reference `patch`.
+When the pull request changed no line that the coverage report instruments, the column is dropped
+instead of showing `-` for every file.
+
 `octocov diff [REPORT_A] [REPORT_B] --patch` also prints the file coverage table of the comparison,
 including its patch coverage column, fetching the changed files and lines via the GitHub API. Since
 `--patch` asks for that data explicitly, it fails rather than printing nothing when the data cannot

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -102,7 +102,7 @@ func createReportContent(ctx context.Context, c *config.Config, r, rPrev *report
 	if message != "" {
 		comment = append(comment, message)
 	}
-	if err := c.Acceptable(r, rPrev, gh.ChangedLinesByFile(files)); err != nil {
+	if err := c.Acceptable(r, rPrev, r.PatchCoverage(gh.ChangedLinesByFile(files))); err != nil {
 		errs := errors.Errors(err)
 		var b strings.Builder
 		for _, e := range errs {

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/k1LoW/errors"
 	"github.com/k1LoW/octocov/config"
+	"github.com/k1LoW/octocov/coverage"
 	"github.com/k1LoW/octocov/gh"
 	"github.com/k1LoW/octocov/report"
 )
@@ -102,7 +103,13 @@ func createReportContent(ctx context.Context, c *config.Config, r, rPrev *report
 	if message != "" {
 		comment = append(comment, message)
 	}
-	if err := c.Acceptable(r, rPrev, r.PatchCoverage(gh.ChangedLinesByFile(files))); err != nil {
+	// Measure patch coverage only when the condition can read it, so a configuration that
+	// never references `patch` does not pay for the lookup over every changed file.
+	var pc *coverage.PatchCoverage
+	if c.Coverage.AcceptableReferencesPatch() && c.CoverageConfigReady() == nil {
+		pc = r.PatchCoverage(gh.ChangedLinesByFile(files))
+	}
+	if err := c.Acceptable(r, rPrev, pc); err != nil {
 		errs := errors.Errors(err)
 		var b strings.Builder
 		for _, e := range errs {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/k1LoW/octocov/badge"
 	"github.com/k1LoW/octocov/central"
 	"github.com/k1LoW/octocov/config"
+	"github.com/k1LoW/octocov/coverage"
 	"github.com/k1LoW/octocov/datastore"
 	"github.com/k1LoW/octocov/gh"
 	"github.com/k1LoW/octocov/internal"
@@ -457,6 +458,31 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		// Measure patch coverage before storing the report, because storing the report shrinks
+		// away the block coverages that patch coverage is derived from.
+		var patchCoverage *coverage.PatchCoverage
+		if c.Coverage.AcceptableReferencesPatch() {
+			if err := c.CoverageConfigReady(); err != nil {
+				cmd.PrintErrf("Skip measuring patch coverage: %v\n", err)
+			} else {
+				files, err := fetchPullRequestFilesForPatchCoverage(ctx, c.Repository)
+				changedFiles := gh.ChangedLinesByFile(files)
+				switch {
+				case err != nil:
+					cmd.PrintErrf("Skip measuring patch coverage: %v\n", err)
+				case len(files) == 0:
+					cmd.PrintErrln("Skip measuring patch coverage: no changed files were fetched")
+				case len(changedFiles) == 0:
+					cmd.PrintErrln("Skip measuring patch coverage: no changed lines were fetched")
+				default:
+					patchCoverage = r.PatchCoverage(changedFiles)
+					if patchCoverage.Total == 0 {
+						cmd.PrintErrln("Skip measuring patch coverage: no changed line is instrumented by the coverage report")
+					}
+				}
+			}
+		}
+
 		// Store report
 		if err := c.ReportConfigReady(); err != nil {
 			cmd.PrintErrf("Skip storing report: %v\n", err)
@@ -498,19 +524,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		// Check for acceptable code metrics
-		var changedFiles map[string][]int
-		if c.Coverage.AcceptableReferencesPatch() {
-			files, err := fetchPullRequestFilesForPatchCoverage(ctx, c.Repository)
-			switch {
-			case err != nil:
-				cmd.PrintErrf("Skip measuring patch coverage: %v\n", err)
-			case len(files) == 0:
-				cmd.PrintErrln("Skip measuring patch coverage: no changed files were fetched")
-			default:
-				changedFiles = gh.ChangedLinesByFile(files)
-			}
-		}
-		if err := c.Acceptable(r, rPrev, changedFiles); err != nil {
+		if err := c.Acceptable(r, rPrev, patchCoverage); err != nil {
 			return err
 		}
 
@@ -536,6 +550,7 @@ func fetchPullRequestFilesForPatchCoverage(ctx context.Context, repository strin
 	}
 	return g.FetchChangedFiles(ctx, repo.Owner, repo.Repo)
 }
+
 func printMetrics(cmd *cobra.Command) error {
 	ctx := context.Background()
 	c := config.New()

--- a/config/config.go
+++ b/config/config.go
@@ -218,22 +218,23 @@ type Reporter interface {
 	TestExecutionTimeNano() float64
 	IsMeasuredTestExecutionTime() bool
 	CustomMetricsAcceptable(Reporter) error
-	PatchCoverage(changedFiles map[string][]int) *cov.PatchCoverage
 }
 
 // Acceptable checks r (and rPrev, for comparison) against the configured acceptable conditions.
-// changedFiles maps a file path to the line numbers changed in that file (e.g. lines changed in a
-// pull request), and is used to compute the `patch` variable for `coverage.acceptable:`. Pass nil
-// if no pull request context is available; `patch` then falls back to defaultPatchCoverage, and
-// the condition is still evaluated.
-func (c *Config) Acceptable(r, rPrev Reporter, changedFiles map[string][]int) error {
+// pc is the already measured patch coverage, used for the `patch` variable of
+// `coverage.acceptable:`. Pass nil if it could not be measured; `patch` then falls back to
+// defaultPatchCoverage, and the condition is still evaluated.
+//
+// Patch coverage is passed in already measured rather than computed here, because it is derived
+// from the block coverages, which the caller shrinks away once the report has been stored.
+func (c *Config) Acceptable(r, rPrev Reporter, pc *cov.PatchCoverage) error {
 	var errs error
 	if err := c.CoverageConfigReady(); err == nil {
 		prev := big.NewRat(int64(rPrev.CoveragePercent()*10000), 10000)
 		curr := big.NewRat(int64(r.CoveragePercent()*10000), 10000)
 		var patch *float64
 		if c.Coverage.AcceptableReferencesPatch() {
-			patch = buildPatchAcceptableVar(r, changedFiles)
+			patch = buildPatchAcceptableVar(pc)
 		}
 		if err := coverageAcceptable(curr, prev, c.Coverage.Acceptable, patch); err != nil {
 			errs = errors.Join(errs, err)
@@ -286,16 +287,12 @@ var (
 const defaultPatchCoverage = 100.0
 
 // buildPatchAcceptableVar computes the `patch` variable for `coverage.acceptable:`.
-// It returns nil if changedFiles is unavailable (no pull request context) or the pull request
-// changed no lines that the coverage report instruments, in which case defaultPatchCoverage
-// is used instead of a zero/undefined value. Reporting why patch coverage was not measured is
-// left to the caller, as with the other metrics.
-func buildPatchAcceptableVar(r Reporter, changedFiles map[string][]int) *float64 {
-	if changedFiles == nil {
-		return nil
-	}
-	pc := r.PatchCoverage(changedFiles)
-	if pc.Total == 0 {
+// It returns nil if patch coverage could not be measured (no pull request context, or the pull
+// request changed no line that the coverage report instruments), in which case
+// defaultPatchCoverage is used instead of a zero/undefined value. Reporting why patch coverage
+// was not measured is left to the caller, as with the other metrics.
+func buildPatchAcceptableVar(pc *cov.PatchCoverage) *float64 {
+	if pc == nil || pc.Total == 0 {
 		return nil
 	}
 	rate := pc.Rate()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	cov "github.com/k1LoW/octocov/coverage"
 	"golang.org/x/text/language"
 )
 
@@ -520,4 +521,67 @@ func rootTestdataDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return dir
+}
+
+func TestBuildPatchAcceptableVar(t *testing.T) {
+	tests := []struct {
+		name string
+		pc   *cov.PatchCoverage
+		want *float64
+	}{
+		{"not measured", nil, nil},
+		{"no changed line is instrumented", &cov.PatchCoverage{}, nil},
+		{"measured", &cov.PatchCoverage{Total: 4, Covered: 3}, float64Ptr(75.0)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(buildPatchAcceptableVar(tt.pc), tt.want, nil); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+// TestAcceptablePatchCoverage pins how `coverage.acceptable:` treats the `patch` variable.
+// A measured patch coverage is enforced as a threshold. An unmeasurable one falls back to a
+// permissive value, while any non-patch term of the condition keeps being enforced.
+func TestAcceptablePatchCoverage(t *testing.T) {
+	tests := []struct {
+		name    string
+		cond    string
+		pc      *cov.PatchCoverage
+		wantErr bool
+	}{
+		{"measured, above the threshold", "patch >= 70%", &cov.PatchCoverage{Total: 4, Covered: 3}, false},
+		{"measured, below the threshold", "patch >= 80%", &cov.PatchCoverage{Total: 4, Covered: 3}, true},
+		{"not measured", "patch >= 80%", nil, false},
+		{"measured, but no changed line is instrumented", "patch >= 80%", &cov.PatchCoverage{}, false},
+		{"not measured, non-patch term still enforced", "current >= 90% && patch >= 80%", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{Coverage: &Coverage{Paths: []string{"."}, Acceptable: tt.cond}}
+			err := c.Acceptable(&patchReporter{coverage: 85.0}, &patchReporter{}, tt.pc)
+			if tt.wantErr && err == nil {
+				t.Error("got nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("got %v, want nil", err)
+			}
+		})
+	}
+}
+
+type patchReporter struct {
+	coverage float64
+}
+
+func (r *patchReporter) CoveragePercent() float64               { return r.coverage }
+func (r *patchReporter) CodeToTestRatioRatio() float64          { return 0 }
+func (r *patchReporter) TestExecutionTimeNano() float64         { return 0 }
+func (r *patchReporter) IsMeasuredTestExecutionTime() bool      { return false }
+func (r *patchReporter) CustomMetricsAcceptable(Reporter) error { return nil }
+
+func float64Ptr(f float64) *float64 {
+	return &f
 }

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -312,6 +312,11 @@ func (fc *FileCoverage) FindBlocksByLine(n int) BlockCoverages {
 	if len(fc.cache) == 0 {
 		fc.cache = map[int]BlockCoverages{}
 		for _, b := range fc.Blocks {
+			// A stored report can omit the line range, since both fields are omitempty.
+			// Such a block contributes no lines rather than being assumed to start at 0.
+			if b.StartLine == nil || b.EndLine == nil {
+				continue
+			}
 			for i := *b.StartLine; i <= *b.EndLine; i++ {
 				_, ok := fc.cache[i]
 				if !ok {

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -265,6 +265,9 @@ func New() *Coverage {
 func (c *Coverage) DeleteBlockCoverages() {
 	for _, f := range c.Files {
 		f.Blocks = BlockCoverages{}
+		// Drop the line cache too. Leaving it would keep FindBlocksByLine answering from
+		// blocks that no longer exist.
+		f.cache = nil
 	}
 }
 

--- a/coverage/patch_test.go
+++ b/coverage/patch_test.go
@@ -113,3 +113,49 @@ func intPtr(i int) *int {
 func execCountPtr(c ExecCount) *ExecCount {
 	return &c
 }
+
+func TestPatchCoverageAfterDeleteBlockCoverages(t *testing.T) {
+	// Storing a report shrinks away the block coverages, and patch coverage is derived from
+	// them. Once shrunk, patch coverage reads as unmeasurable (Total 0) rather than being
+	// answered from the line cache built before the shrink.
+	c := &Coverage{
+		Files: FileCoverages{
+			&FileCoverage{
+				File: "a.go",
+				Blocks: BlockCoverages{
+					&BlockCoverage{StartLine: intPtr(1), EndLine: intPtr(2), Count: execCountPtr(1)},
+				},
+			},
+		},
+	}
+	changedFiles := map[string][]int{"a.go": {1, 2}}
+
+	if got := c.PatchCoverage(changedFiles); got.Total != 2 {
+		t.Fatalf("Total before shrink got %v want 2", got.Total)
+	}
+
+	c.DeleteBlockCoverages()
+
+	if got := c.PatchCoverage(changedFiles); got.Total != 0 {
+		t.Errorf("Total after shrink got %v want 0", got.Total)
+	}
+}
+
+func TestPatchCoverageWithBlockMissingLineRange(t *testing.T) {
+	// A report unmarshaled from a datastore can carry a block whose line range was omitted.
+	// Such a block instruments no line, and must not take the whole measurement down with it.
+	fc := &FileCoverage{
+		File: "a.go",
+		Blocks: BlockCoverages{
+			&BlockCoverage{Count: execCountPtr(1)},
+			&BlockCoverage{StartLine: intPtr(3), EndLine: intPtr(3), Count: execCountPtr(1)},
+		},
+	}
+	got := fc.PatchCoverage([]int{1, 2, 3})
+	if got.Total != 1 {
+		t.Errorf("Total got %v want 1", got.Total)
+	}
+	if got.Covered != 1 {
+		t.Errorf("Covered got %v want 1", got.Covered)
+	}
+}

--- a/report/diff_report_test.go
+++ b/report/diff_report_test.go
@@ -101,7 +101,7 @@ func TestDiffFileCoveragesTableWithPatch(t *testing.T) {
 	got := a.Compare(b).FileCoveragesTable([]*gh.PullRequestFile{ //nostyle:funcfmt
 		{Filename: "zcase/added.go", BlobURL: "https://github.com/k1LoW/octocov/blob/afterhash/zcase/added.go", Status: "added", ChangedLines: []int{1, 2, 3, 4, 5, 6, 7, 8, 9}},
 		{Filename: "zcase/added_test.go", BlobURL: "https://github.com/k1LoW/octocov/blob/afterhash/zcase/added_test.go", Status: "added"},
-		{Filename: "zcase/affected_test.go", BlobURL: "https://github.com/k1LoW/octocov/blob/afterhash/zcase/affected.go", Status: "modified", ChangedLines: []int{9, 10, 11}},
+		{Filename: "zcase/affected.go", BlobURL: "https://github.com/k1LoW/octocov/blob/afterhash/zcase/affected.go", Status: "modified", ChangedLines: []int{9, 10, 11}},
 		{Filename: "zcase/removed.go", BlobURL: "https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed.go", Status: "removed"},
 		{Filename: "zcase/removed_test.go", BlobURL: "https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed_test.go", Status: "removed"},
 		{Filename: "zcase/rename_new.go", BlobURL: "https://github.com/k1LoW/octocov/blob/afterhash/zcase/rename_new.go", Status: "renamed", ChangedLines: []int{5, 6, 9}},

--- a/testdata/diff_file_coverages_table_with_patch.golden
+++ b/testdata/diff_file_coverages_table_with_patch.golden
@@ -1,9 +1,9 @@
-### Code coverage of files in pull request scope (75.0% → 58.3%, patch 77.7%)
+### Code coverage of files in pull request scope (75.0% → 58.3%, patch 58.3%)
 
 |                                            Files                                            | Coverage |  +/-   | Patch Coverage |  Status  |
 |---------------------------------------------------------------------------------------------|---------:|-------:|---------------:|---------:|
 | [zcase/added.go](https://github.com/k1LoW/octocov/blob/afterhash/zcase/added.go)            | 66.6%    | +66.6% | 83.3%          | added    |
-| [zcase/affected.go](https://github.com/k1LoW/octocov/blob/afterhash/zcase/affected.go)      | 50.0%    | -33.4% | -              | affected |
+| [zcase/affected.go](https://github.com/k1LoW/octocov/blob/afterhash/zcase/affected.go)      | 50.0%    | -33.4% | 0.0%           | modified |
 | [zcase/removed.go](https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed.go)       | 0.0%     | -66.7% | -              | removed  |
 | [zcase/rename_new.go](https://github.com/k1LoW/octocov/blob/afterhash/zcase/rename_new.go)  | 66.6%    | +66.6% | 66.6%          | renamed  |
 | [zcase/rename_old.go](https://github.com/k1LoW/octocov/blob/beforehash/zcase/rename_old.go) | 0.0%     | -66.7% | -              | affected |


### PR DESCRIPTION
## Summary

- The `patch` acceptable variable added in #636 was inert in the standard configuration. `reportToDatastores` calls `DeleteBlockCoverages` once the report has been stored, and patch coverage is derived from those blocks, so the acceptable check that runs afterwards saw an empty report. `patch` fell back to `defaultPatchCoverage` and `acceptable: patch >= N` passed unconditionally whenever `report.path:` or `report.datastores:` was set.
- It appeared to work only because the line cache behind `FindBlocksByLine` outlived the blocks it was built from, so a preceding `comment:`, `summary:` or `body:` render left a stale cache for the check to read. Whether the gate had any effect therefore depended on configuration unrelated to it.
- Measure patch coverage before storing and pass the result down, rather than moving the check itself, which would also change whether badges and reports are pushed when the gate fails. `Config.Acceptable` now takes the measured coverage, so `Reporter` no longer needs a `PatchCoverage` method and out-of-tree implementations keep working.
- Two smaller defects in the same path, each in its own commit. `DeleteBlockCoverages` now drops the line cache along with the blocks, and `FindBlocksByLine` skips a block whose `omitempty` line range is absent instead of panicking on it. That dereference had no caller before #636.
- The `patch` measurement is now gated on `CoverageConfigReady()`, since `Acceptable` evaluates the coverage condition only when that passes, and it reports the case where files were fetched but carried no changed line.

The regression test was checked against the bug rather than only against the fix. With the cache invalidation reverted, `TestPatchCoverageAfterDeleteBlockCoverages` fails with `Total after shrink got 2 want 0`, so it pins the defect and not just the current behavior.

One caveat unrelated to this change. `golangci-lint run ./...` does not finish within the `timeout: 2m` in `.golangci.yml` on my machine. Re-run with `--timeout 15m` it reports two issues, both `SA1019` deprecations of `credentials.DetectOptions.CredentialsJSON` in `datastore/datastore.go`, a file this PR does not touch, and none in the changed packages. That run still ended with `Timeout exceeded`, so treat its coverage as incomplete rather than as a clean pass. `go vet` and `gostyle` report no issues on the changed packages.

Ref: #636
