### PR TITLE
refactor: fix the lint failures that came with Go 1.26

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -531,7 +531,7 @@ func TestBuildPatchAcceptableVar(t *testing.T) {
 	}{
 		{"not measured", nil, nil},
 		{"no changed line is instrumented", &cov.PatchCoverage{}, nil},
-		{"measured", &cov.PatchCoverage{Total: 4, Covered: 3}, float64Ptr(75.0)},
+		{"measured", &cov.PatchCoverage{Total: 4, Covered: 3}, new(75.0)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -581,7 +581,3 @@ func (r *patchReporter) CodeToTestRatioRatio() float64          { return 0 }
 func (r *patchReporter) TestExecutionTimeNano() float64         { return 0 }
 func (r *patchReporter) IsMeasuredTestExecutionTime() bool      { return false }
 func (r *patchReporter) CustomMetricsAcceptable(Reporter) error { return nil }
-
-func float64Ptr(f float64) *float64 {
-	return &f
-}

--- a/config/ready_test.go
+++ b/config/ready_test.go
@@ -727,14 +727,14 @@ func mockedGh(t *testing.T) *gh.Gh {
 		mock.WithRequestMatch( //nostyle:funcfmt
 			mock.GetReposByOwnerByRepo,
 			github.Repository{
-				DefaultBranch: github.String("main"),
+				DefaultBranch: new("main"),
 			},
 		),
 		mock.WithRequestMatch( //nostyle:funcfmt
 			mock.GetReposPullsByOwnerByRepoByPullNumber,
 			github.PullRequest{
-				Number: github.Int(13),
-				Draft:  github.Bool(true),
+				Number: new(13),
+				Draft:  new(true),
 			},
 		),
 	)

--- a/coverage/patch_test.go
+++ b/coverage/patch_test.go
@@ -6,10 +6,10 @@ func TestFileCoveragePatchCoverage(t *testing.T) {
 	fc := &FileCoverage{
 		File: "main.go",
 		Blocks: BlockCoverages{
-			&BlockCoverage{StartLine: intPtr(1), EndLine: intPtr(1), Count: execCountPtr(1)},
-			&BlockCoverage{StartLine: intPtr(2), EndLine: intPtr(2), Count: execCountPtr(0)},
-			&BlockCoverage{StartLine: intPtr(3), EndLine: intPtr(3), Count: execCountPtr(2)},
-			&BlockCoverage{StartLine: intPtr(4), EndLine: intPtr(4), Count: execCountPtr(0)},
+			&BlockCoverage{StartLine: new(1), EndLine: new(1), Count: new(ExecCount(1))},
+			&BlockCoverage{StartLine: new(2), EndLine: new(2), Count: new(ExecCount(0))},
+			&BlockCoverage{StartLine: new(3), EndLine: new(3), Count: new(ExecCount(2))},
+			&BlockCoverage{StartLine: new(4), EndLine: new(4), Count: new(ExecCount(0))},
 		},
 	}
 	got := fc.PatchCoverage([]int{1, 2, 3, 4})
@@ -31,8 +31,8 @@ func TestFileCoveragePatchCoverageExcludesUninstrumentedLines(t *testing.T) {
 	fc := &FileCoverage{
 		File: "new.go",
 		Blocks: BlockCoverages{
-			&BlockCoverage{Type: TypeStmt, StartLine: intPtr(5), EndLine: intPtr(6), Count: execCountPtr(3)},
-			&BlockCoverage{Type: TypeStmt, StartLine: intPtr(9), EndLine: intPtr(10), Count: execCountPtr(3)},
+			&BlockCoverage{Type: TypeStmt, StartLine: new(5), EndLine: new(6), Count: new(ExecCount(3))},
+			&BlockCoverage{Type: TypeStmt, StartLine: new(9), EndLine: new(10), Count: new(ExecCount(3))},
 		},
 	}
 	got := fc.PatchCoverage([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})
@@ -51,7 +51,7 @@ func TestFileCoveragePatchCoverageNoInstrumentedChangedLines(t *testing.T) {
 	fc := &FileCoverage{
 		File: "main.go",
 		Blocks: BlockCoverages{
-			&BlockCoverage{Type: TypeStmt, StartLine: intPtr(10), EndLine: intPtr(11), Count: execCountPtr(1)},
+			&BlockCoverage{Type: TypeStmt, StartLine: new(10), EndLine: new(11), Count: new(ExecCount(1))},
 		},
 	}
 	got := fc.PatchCoverage([]int{1, 2, 3})
@@ -74,15 +74,15 @@ func TestCoveragePatchCoverage(t *testing.T) {
 			&FileCoverage{
 				File: "a.go",
 				Blocks: BlockCoverages{
-					&BlockCoverage{StartLine: intPtr(1), EndLine: intPtr(1), Count: execCountPtr(1)},
-					&BlockCoverage{StartLine: intPtr(2), EndLine: intPtr(2), Count: execCountPtr(0)},
+					&BlockCoverage{StartLine: new(1), EndLine: new(1), Count: new(ExecCount(1))},
+					&BlockCoverage{StartLine: new(2), EndLine: new(2), Count: new(ExecCount(0))},
 				},
 			},
 			&FileCoverage{
 				File: "b.go",
 				Blocks: BlockCoverages{
-					&BlockCoverage{StartLine: intPtr(1), EndLine: intPtr(1), Count: execCountPtr(0)},
-					&BlockCoverage{StartLine: intPtr(2), EndLine: intPtr(2), Count: execCountPtr(0)},
+					&BlockCoverage{StartLine: new(1), EndLine: new(1), Count: new(ExecCount(0))},
+					&BlockCoverage{StartLine: new(2), EndLine: new(2), Count: new(ExecCount(0))},
 				},
 			},
 		},
@@ -106,14 +106,6 @@ func TestCoveragePatchCoverage(t *testing.T) {
 	}
 }
 
-func intPtr(i int) *int {
-	return &i
-}
-
-func execCountPtr(c ExecCount) *ExecCount {
-	return &c
-}
-
 func TestPatchCoverageAfterDeleteBlockCoverages(t *testing.T) {
 	// Storing a report shrinks away the block coverages, and patch coverage is derived from
 	// them. Once shrunk, patch coverage reads as unmeasurable (Total 0) rather than being
@@ -123,7 +115,7 @@ func TestPatchCoverageAfterDeleteBlockCoverages(t *testing.T) {
 			&FileCoverage{
 				File: "a.go",
 				Blocks: BlockCoverages{
-					&BlockCoverage{StartLine: intPtr(1), EndLine: intPtr(2), Count: execCountPtr(1)},
+					&BlockCoverage{StartLine: new(1), EndLine: new(2), Count: new(ExecCount(1))},
 				},
 			},
 		},
@@ -147,8 +139,8 @@ func TestPatchCoverageWithBlockMissingLineRange(t *testing.T) {
 	fc := &FileCoverage{
 		File: "a.go",
 		Blocks: BlockCoverages{
-			&BlockCoverage{Count: execCountPtr(1)},
-			&BlockCoverage{StartLine: intPtr(3), EndLine: intPtr(3), Count: execCountPtr(1)},
+			&BlockCoverage{Count: new(ExecCount(1))},
+			&BlockCoverage{StartLine: new(3), EndLine: new(3), Count: new(ExecCount(1))},
 		},
 	}
 	got := fc.PatchCoverage([]int{1, 2, 3})
@@ -169,8 +161,8 @@ func TestCoveragePatchCoverageMergesPathsMatchingOneFile(t *testing.T) {
 			&FileCoverage{
 				File: "foo/bar.go",
 				Blocks: BlockCoverages{
-					&BlockCoverage{StartLine: intPtr(1), EndLine: intPtr(1), Count: execCountPtr(1)},
-					&BlockCoverage{StartLine: intPtr(2), EndLine: intPtr(2), Count: execCountPtr(0)},
+					&BlockCoverage{StartLine: new(1), EndLine: new(1), Count: new(ExecCount(1))},
+					&BlockCoverage{StartLine: new(2), EndLine: new(2), Count: new(ExecCount(0))},
 				},
 			},
 		},
@@ -195,7 +187,7 @@ func TestFileCoveragePatchCoverageCountsEachLineOnce(t *testing.T) {
 	fc := &FileCoverage{
 		File: "a.go",
 		Blocks: BlockCoverages{
-			&BlockCoverage{StartLine: intPtr(1), EndLine: intPtr(1), Count: execCountPtr(1)},
+			&BlockCoverage{StartLine: new(1), EndLine: new(1), Count: new(ExecCount(1))},
 		},
 	}
 	got := fc.PatchCoverage([]int{1, 1, 1})

--- a/datastore/credentials_test.go
+++ b/datastore/credentials_test.go
@@ -1,0 +1,55 @@
+package datastore
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCredentialsFromJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr string
+	}{
+		{
+			"service_account",
+			`{"type":"service_account","project_id":"p","private_key_id":"k","private_key":"dummy","client_email":"sa@p.iam.gserviceaccount.com","client_id":"1","token_uri":"https://oauth2.googleapis.com/token"}`,
+			"",
+		},
+		{
+			"authorized_user",
+			`{"type":"authorized_user","client_id":"c","client_secret":"s","refresh_token":"r"}`,
+			"",
+		},
+		{
+			"unknown type",
+			`{"type":"unknown"}`,
+			"unsupported filetype",
+		},
+		{
+			"invalid json",
+			`not json`,
+			"invalid character",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := credentialsFromJSON([]byte(tt.in), []string{"https://www.googleapis.com/auth/cloud-platform"})
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("want error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if creds == nil {
+				t.Error("want credentials, got nil")
+			}
+		})
+	}
+}

--- a/datastore/credentials_test.go
+++ b/datastore/credentials_test.go
@@ -22,6 +22,11 @@ func TestCredentialsFromJSON(t *testing.T) {
 			"",
 		},
 		{
+			"missing type",
+			`{"client_id":"c","client_secret":"s","refresh_token":"r"}`,
+			"unsupported unidentified file type",
+		},
+		{
 			"unknown type",
 			`{"type":"unknown"}`,
 			"unsupported filetype",

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -259,9 +259,13 @@ func credentialsFromJSON(b []byte, scopes []string) (*auth.Credentials, error) {
 		Type string `json:"type"`
 	}
 	if err := json.Unmarshal(b, &f); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GOOGLE_APPLICATION_CREDENTIALS_JSON: %w", err)
 	}
-	return credentials.NewCredentialsFromJSON(credentials.CredType(f.Type), b, &credentials.DetectOptions{
+	creds, err := credentials.NewCredentialsFromJSON(credentials.CredType(f.Type), b, &credentials.DetectOptions{
 		Scopes: scopes,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("GOOGLE_APPLICATION_CREDENTIALS_JSON: %w", err)
+	}
+	return creds, nil
 }

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/credentials"
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/storage"
@@ -116,10 +118,7 @@ func New(ctx context.Context, u string, hints ...HintFunc) (Datastore, error) {
 		prefix := args[1]
 		var client *storage.Client
 		if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON") != "" {
-			creds, err := credentials.DetectDefault(&credentials.DetectOptions{
-				Scopes:          []string{storage.ScopeFullControl},
-				CredentialsJSON: []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")),
-			})
+			creds, err := credentialsFromJSON([]byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")), []string{storage.ScopeFullControl})
 			if err != nil {
 				return nil, err
 			}
@@ -140,10 +139,7 @@ func New(ctx context.Context, u string, hints ...HintFunc) (Datastore, error) {
 		table := args[2]
 		var client *bigquery.Client
 		if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON") != "" {
-			creds, err := credentials.DetectDefault(&credentials.DetectOptions{
-				Scopes:          []string{bigquery.Scope},
-				CredentialsJSON: []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")),
-			})
+			creds, err := credentialsFromJSON([]byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")), []string{bigquery.Scope})
 			if err != nil {
 				return nil, err
 			}
@@ -252,4 +248,20 @@ func parse(u, root string) (Type, []string, error) {
 
 func NeedToShrink(u string) bool {
 	return strings.HasPrefix(u, "bq://")
+}
+
+// credentialsFromJSON builds credentials from the JSON in GOOGLE_APPLICATION_CREDENTIALS_JSON.
+// The credential type is read from the JSON itself instead of being fixed to one CredType.
+// octocov has never restricted which type users supply here, and the JSON is the user's own
+// secret rather than an externally sourced configuration.
+func credentialsFromJSON(b []byte, scopes []string) (*auth.Credentials, error) {
+	var f struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(b, &f); err != nil {
+		return nil, err
+	}
+	return credentials.NewCredentialsFromJSON(credentials.CredType(f.Type), b, &credentials.DetectOptions{
+		Scopes: scopes,
+	})
 }

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -259,13 +259,13 @@ func credentialsFromJSON(b []byte, scopes []string) (*auth.Credentials, error) {
 		Type string `json:"type"`
 	}
 	if err := json.Unmarshal(b, &f); err != nil {
-		return nil, fmt.Errorf("GOOGLE_APPLICATION_CREDENTIALS_JSON: %w", err)
+		return nil, fmt.Errorf("env %s: %w", "GOOGLE_APPLICATION_CREDENTIALS_JSON", err)
 	}
 	creds, err := credentials.NewCredentialsFromJSON(credentials.CredType(f.Type), b, &credentials.DetectOptions{
 		Scopes: scopes,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("GOOGLE_APPLICATION_CREDENTIALS_JSON: %w", err)
+		return nil, fmt.Errorf("env %s: %w", "GOOGLE_APPLICATION_CREDENTIALS_JSON", err)
 	}
 	return creds, nil
 }

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -80,9 +80,9 @@ func (g *Gh) PushContent(ctx context.Context, owner, repo, branch, content, cp, 
 
 	if cp != "" {
 		blob := &github.Blob{
-			Content:  github.String(content),
-			Encoding: github.String("utf-8"),
-			Size:     github.Int(len(content)),
+			Content:  new(content),
+			Encoding: new("utf-8"),
+			Size:     new(len(content)),
 		}
 
 		resB, _, err := srv.CreateBlob(ctx, owner, repo, blob)
@@ -91,9 +91,9 @@ func (g *Gh) PushContent(ctx context.Context, owner, repo, branch, content, cp, 
 		}
 
 		entry := &github.TreeEntry{
-			Path: github.String(cp),
-			Mode: github.String("100644"),
-			Type: github.String("blob"),
+			Path: new(cp),
+			Mode: new("100644"),
+			Type: new("blob"),
 			SHA:  resB.SHA,
 		}
 
@@ -111,7 +111,7 @@ func (g *Gh) PushContent(ctx context.Context, owner, repo, branch, content, cp, 
 	}
 
 	commit := &github.Commit{
-		Message: github.String(message),
+		Message: new(message),
 		Tree:    tree,
 		Parents: []*github.Commit{parent},
 	}
@@ -121,9 +121,9 @@ func (g *Gh) PushContent(ctx context.Context, owner, repo, branch, content, cp, 
 	}
 
 	nref := &github.Reference{
-		Ref: github.String(path.Join("refs", "heads", branch)),
+		Ref: new(path.Join("refs", "heads", branch)),
 		Object: &github.GitObject{
-			Type: github.String("commit"),
+			Type: new("commit"),
 			SHA:  resC.SHA,
 		},
 	}

--- a/gh/gh_test.go
+++ b/gh/gh_test.go
@@ -253,7 +253,7 @@ func mockedGh(t *testing.T) *Gh {
 		mock.WithRequestMatch( //nostyle:funcfmt
 			mock.GetReposByOwnerByRepo,
 			github.Repository{
-				DefaultBranch: github.String("main"),
+				DefaultBranch: new("main"),
 			},
 		),
 		mock.WithRequestMatch( //nostyle:funcfmt
@@ -261,13 +261,13 @@ func mockedGh(t *testing.T) *Gh {
 			[]*github.PullRequest{
 				{
 					Head: &github.PullRequestBranch{
-						Ref: github.String("branch/branch/name"),
+						Ref: new("branch/branch/name"),
 						Repo: &github.Repository{
-							Owner: &github.User{Login: github.String("owner")},
-							Name:  github.String("repo"),
+							Owner: &github.User{Login: new("owner")},
+							Name:  new("repo"),
 						},
 					},
-					Number: github.Int(13),
+					Number: new(13),
 				},
 			},
 		),
@@ -297,12 +297,12 @@ func TestDetectCurrentPullRequestNumberSkipsForkPR(t *testing.T) {
 			GITHUB_REF: "refs/heads/feature-branch",
 			prs: []*github.PullRequest{
 				{
-					Number: github.Int(10),
+					Number: new(10),
 					Head: &github.PullRequestBranch{
-						Ref: github.String("feature-branch"),
+						Ref: new("feature-branch"),
 						Repo: &github.Repository{
-							Owner: &github.User{Login: github.String("owner")},
-							Name:  github.String("repo"),
+							Owner: &github.User{Login: new("owner")},
+							Name:  new("repo"),
 						},
 					},
 				},
@@ -315,12 +315,12 @@ func TestDetectCurrentPullRequestNumberSkipsForkPR(t *testing.T) {
 			GITHUB_REF: "refs/heads/main",
 			prs: []*github.PullRequest{
 				{
-					Number: github.Int(20),
+					Number: new(20),
 					Head: &github.PullRequestBranch{
-						Ref: github.String("main"),
+						Ref: new("main"),
 						Repo: &github.Repository{
-							Owner: &github.User{Login: github.String("forked-user")},
-							Name:  github.String("repo"),
+							Owner: &github.User{Login: new("forked-user")},
+							Name:  new("repo"),
 						},
 					},
 				},
@@ -333,22 +333,22 @@ func TestDetectCurrentPullRequestNumberSkipsForkPR(t *testing.T) {
 			GITHUB_REF: "refs/heads/main",
 			prs: []*github.PullRequest{
 				{
-					Number: github.Int(20),
+					Number: new(20),
 					Head: &github.PullRequestBranch{
-						Ref: github.String("main"),
+						Ref: new("main"),
 						Repo: &github.Repository{
-							Owner: &github.User{Login: github.String("forked-user")},
-							Name:  github.String("repo"),
+							Owner: &github.User{Login: new("forked-user")},
+							Name:  new("repo"),
 						},
 					},
 				},
 				{
-					Number: github.Int(30),
+					Number: new(30),
 					Head: &github.PullRequestBranch{
-						Ref: github.String("main"),
+						Ref: new("main"),
 						Repo: &github.Repository{
-							Owner: &github.User{Login: github.String("owner")},
-							Name:  github.String("repo"),
+							Owner: &github.User{Login: new("owner")},
+							Name:  new("repo"),
 						},
 					},
 				},
@@ -361,12 +361,12 @@ func TestDetectCurrentPullRequestNumberSkipsForkPR(t *testing.T) {
 			GITHUB_REF: "refs/heads/feature",
 			prs: []*github.PullRequest{
 				{
-					Number: github.Int(25),
+					Number: new(25),
 					Head: &github.PullRequestBranch{
-						Ref: github.String("feature"),
+						Ref: new("feature"),
 						Repo: &github.Repository{
-							Owner: &github.User{Login: github.String("Owner")},
-							Name:  github.String("repo"),
+							Owner: &github.User{Login: new("Owner")},
+							Name:  new("repo"),
 						},
 					},
 				},
@@ -379,9 +379,9 @@ func TestDetectCurrentPullRequestNumberSkipsForkPR(t *testing.T) {
 			GITHUB_REF: "refs/heads/feature",
 			prs: []*github.PullRequest{
 				{
-					Number: github.Int(35),
+					Number: new(35),
 					Head: &github.PullRequestBranch{
-						Ref:  github.String("feature"),
+						Ref:  new("feature"),
 						Repo: nil,
 					},
 				},
@@ -439,16 +439,16 @@ func TestListWorkflowJobs(t *testing.T) {
 		mock.WithRequestMatchPages( //nostyle:funcfmt
 			mock.GetReposActionsRunsJobsByOwnerByRepoByRunId,
 			github.Jobs{
-				TotalCount: github.Int(3),
+				TotalCount: new(3),
 				Jobs: []*github.WorkflowJob{
-					{ID: github.Int64(1), Name: github.String("test (1)")},
-					{ID: github.Int64(2), Name: github.String("test (2)")},
+					{ID: github.Int64(1), Name: new("test (1)")},
+					{ID: github.Int64(2), Name: new("test (2)")},
 				},
 			},
 			github.Jobs{
-				TotalCount: github.Int(3),
+				TotalCount: new(3),
 				Jobs: []*github.WorkflowJob{
-					{ID: github.Int64(3), Name: github.String("test (3)")},
+					{ID: github.Int64(3), Name: new("test (3)")},
 				},
 			},
 		),
@@ -494,7 +494,7 @@ func TestFetchStepsByNameErrors(t *testing.T) {
 			jobs: []*github.WorkflowJob{
 				{ID: github.Int64(1), Steps: []*github.TaskStep{
 					{
-						Name:        github.String("Run test"),
+						Name:        new("Run test"),
 						StartedAt:   &github.Timestamp{Time: base},
 						CompletedAt: &github.Timestamp{Time: base.Add(time.Minute)},
 					},
@@ -508,7 +508,7 @@ func TestFetchStepsByNameErrors(t *testing.T) {
 			jobs: []*github.WorkflowJob{
 				{ID: github.Int64(1), Steps: []*github.TaskStep{
 					{
-						Name:      github.String("Run test"),
+						Name:      new("Run test"),
 						StartedAt: &github.Timestamp{Time: base},
 					},
 				}},
@@ -525,7 +525,7 @@ func TestFetchStepsByNameErrors(t *testing.T) {
 			mockedHTTPClient := mock.NewMockedHTTPClient( //nostyle:funcfmt
 				mock.WithRequestMatch( //nostyle:funcfmt
 					mock.GetReposActionsRunsJobsByOwnerByRepoByRunId,
-					github.Jobs{TotalCount: github.Int(len(tt.jobs)), Jobs: tt.jobs},
+					github.Jobs{TotalCount: new(len(tt.jobs)), Jobs: tt.jobs},
 				),
 			)
 			client, err := factory.NewGithubClient(factory.HTTPClient(mockedHTTPClient), factory.Timeout(10*time.Second))
@@ -565,8 +565,8 @@ func TestIsSameRepo(t *testing.T) {
 		{
 			name: "exact match",
 			headRepo: &github.Repository{
-				Owner: &github.User{Login: github.String("owner")},
-				Name:  github.String("repo"),
+				Owner: &github.User{Login: new("owner")},
+				Name:  new("repo"),
 			},
 			owner: "owner",
 			repo:  "repo",
@@ -575,8 +575,8 @@ func TestIsSameRepo(t *testing.T) {
 		{
 			name: "owner case insensitive",
 			headRepo: &github.Repository{
-				Owner: &github.User{Login: github.String("Owner")},
-				Name:  github.String("repo"),
+				Owner: &github.User{Login: new("Owner")},
+				Name:  new("repo"),
 			},
 			owner: "owner",
 			repo:  "repo",
@@ -585,8 +585,8 @@ func TestIsSameRepo(t *testing.T) {
 		{
 			name: "different owner",
 			headRepo: &github.Repository{
-				Owner: &github.User{Login: github.String("forked-user")},
-				Name:  github.String("repo"),
+				Owner: &github.User{Login: new("forked-user")},
+				Name:  new("repo"),
 			},
 			owner: "owner",
 			repo:  "repo",
@@ -595,8 +595,8 @@ func TestIsSameRepo(t *testing.T) {
 		{
 			name: "different repo name",
 			headRepo: &github.Repository{
-				Owner: &github.User{Login: github.String("owner")},
-				Name:  github.String("other-repo"),
+				Owner: &github.User{Login: new("owner")},
+				Name:  new("other-repo"),
 			},
 			owner: "owner",
 			repo:  "repo",
@@ -613,7 +613,7 @@ func TestIsSameRepo(t *testing.T) {
 			name: "nil owner in headRepo",
 			headRepo: &github.Repository{
 				Owner: nil,
-				Name:  github.String("repo"),
+				Name:  new("repo"),
 			},
 			owner: "owner",
 			repo:  "repo",

--- a/internal/value.go
+++ b/internal/value.go
@@ -1,9 +1,5 @@
 package internal
 
-func Bool(e bool) *bool {
-	return &e
-}
-
 func IsEnable(e *bool) bool {
 	if e == nil {
 		return true

--- a/internal/value_test.go
+++ b/internal/value_test.go
@@ -4,29 +4,13 @@ import (
 	"testing"
 )
 
-func TestBool(t *testing.T) {
-	tests := []struct {
-		in   bool
-		want bool
-	}{
-		{true, true},
-		{false, false},
-	}
-	for _, tt := range tests {
-		got := Bool(tt.in)
-		if *got != tt.want {
-			t.Errorf("got %v\nwant %v", *got, tt.want)
-		}
-	}
-}
-
 func TestIsEnable(t *testing.T) {
 	tests := []struct {
 		in   *bool
 		want bool
 	}{
-		{Bool(true), true},
-		{Bool(false), false},
+		{new(true), true},
+		{new(false), false},
 		{nil, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Lint on `main` has been red since #714 moved the module to Go 1.26. The failing run reports 19 issues in two groups, and neither is caused by a code change on `main`; both are checks that the toolchain bump switched on.
- **The 17 `modernize` findings are `newexpr`.** `github.String(x)`, `github.Int(x)`, `github.Bool(x)` and the `intPtr` / `execCountPtr` / `float64Ptr` test helpers all exist to take the address of a value, which Go 1.26's `new(expr)` does directly. The calls become `new(...)` and the helpers go away. `internal.Bool` had no caller outside its own package once its test was rewritten, so it is removed rather than kept as a one-line wrapper.
- **The 2 `staticcheck` findings are the `CredentialsJSON` deprecation, and that is the part worth reading.** The deprecation exists because the field loads whatever credential type the JSON declares without the caller saying which one it expected. The replacement `NewCredentialsFromJSON` takes a single `CredType`, and the obvious fix of pinning it to `ServiceAccount` would reject the `authorized_user` and `external_account` JSON that `GOOGLE_APPLICATION_CREDENTIALS_JSON` has accepted since #49, which README does not restrict.
- Instead, `credentialsFromJSON` reads the `type` field from the JSON and passes it through as the `CredType`. Behind the type check, `NewCredentialsFromJSON` calls the same `fileCredentials` that `DetectDefault` did, so every JSON that authenticated before still does. The one path it skips is a `client_credentials.json` without a `type` field, which already failed here because octocov never sets an `AuthHandler`. The JSON is the user's own secret, not an externally sourced configuration, so passing the declared type through is a fair reading of the deprecation rather than a way around it.
- `datastore/credentials_test.go` pins that reading: `service_account` and `authorized_user` JSON both produce credentials, an unknown `type` and malformed JSON both error.

Ref: #714