### PR TITLE
feat: store the report of a ref under a key of its own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,12 @@ jobs:
           OCTOCOV_CUSTOM_METRICS_BENCHMARK_0: ./testdata/custom_metrics/benchmark_0.json
           GOTOOLCHAIN: 'go${{ steps.setup-go.outputs.go-version }}'
 
+      # Storing the report twice in one run makes octocov delete the artifact it wrote
+      # first, which needs the actions write permission. A fork's token is read-only, so
+      # this check only runs where that write is available, which is where it has always
+      # run, since a pull request stored nothing at all while report.if held it back.
       - name: 'RE: Build octocov and run as a action' # for checking re-upload artifact
+        if: ${{ github.event_name != 'pull_request' }}
         uses: ./testdata/actions/coverage
         env:
           MACKEREL_API_KEY: ${{ secrets.MACKEREL_API_KEY }}

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -21,6 +21,5 @@ summary:
 # body:
 #   if: is_pull_request
 report:
-  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}

--- a/README.md
+++ b/README.md
@@ -239,6 +239,16 @@ report:
     - s3://bucket/reports
 ```
 
+The report of the default branch is stored under the repository itself, and the report of any other ref is stored beside it under a key naming that ref.
+
+```
+owner/repo/report.json                  # the default branch
+owner/repo/refs/pull/123/report.json    # pull request #123
+owner/repo/refs/heads/feat/x/report.json
+```
+
+`diff.datastores:` reads the report of the default branch, so the comparison shown on a pull request is against the default branch whether or not the pull requests report as well. Reporting from every run is therefore the default, and `report.if: is_default_branch` is only needed to keep the reports of the other refs out of a datastore, which is worth doing for `github://`, where each report is a commit that stays.
+
 ```yaml
 # .octocov.yml
 report:
@@ -909,6 +919,8 @@ artifact://[owner]/[repo]/[artifactName]
 
 - `artifact://[owner]/[repo]/[artifactName]`
 - `artifact://[owner]/[repo]` ( default artifactName: `octocov-report` )
+
+The report of a ref other than the default branch is stored under an artifact of its own, named by appending `@` and the ref to the artifact name, with the characters an artifact name may not hold replaced by `_` ( e.g. `octocov-report@refs_pull_123`, `octocov-report@refs_heads_feat_x` ).
 
 > **Note** that reporting to the artifact can only be sent from the GitHub Actions of the same repository.
 

--- a/central/central.go
+++ b/central/central.go
@@ -112,6 +112,12 @@ func (c *Central) collectReports() error {
 			if err := json.Unmarshal(b, r); err != nil {
 				return nil
 			}
+			// The datastore also holds the reports of the pull requests and the branches
+			// of each repository. The index describes the state of the default branch, so
+			// only the reports stored under its key belong in it.
+			if r.RefKey() != "" {
+				return nil
+			}
 			current, ok := rsMap[r.Repository]
 			if !ok {
 				if _, err := fmt.Fprintf(os.Stderr, "Collect report of %s\n", r.Repository); err != nil {

--- a/central/central_test.go
+++ b/central/central_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/k1LoW/octocov/config"
+	"github.com/k1LoW/octocov/coverage"
 	"github.com/k1LoW/octocov/datastore"
 	"github.com/k1LoW/octocov/datastore/local"
+	"github.com/k1LoW/octocov/report"
 )
 
 func TestCollectReports(t *testing.T) {
@@ -39,6 +41,63 @@ func TestCollectReports(t *testing.T) {
 	got := ctr.reports
 	if want := 6; len(got) != want {
 		t.Errorf("got %v\nwant %v", len(got), want)
+	}
+}
+
+func TestCollectReportsSkipsReportsOfOtherRefs(t *testing.T) {
+	c := config.New()
+	root := t.TempDir()
+	for path, r := range map[string]*report.Report{
+		filepath.Join("owner", "repo", "report.json"): {
+			Repository: "owner/repo",
+			Ref:        "refs/heads/main",
+			BaseRef:    "refs/heads/main",
+			Coverage:   &coverage.Coverage{Total: 100, Covered: 50},
+		},
+		filepath.Join("owner", "repo", "refs", "pull", "123", "report.json"): {
+			Repository:  "owner/repo",
+			Ref:         "refs/pull/123/merge",
+			BaseRef:     "refs/heads/main",
+			PullRequest: 123,
+			Coverage:    &coverage.Coverage{Total: 100, Covered: 99},
+		},
+	} {
+		p := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, r.Bytes(), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rd, err := local.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bd, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctr := New(&Config{
+		Repository:             "owner/repo",
+		Index:                  ".",
+		Wd:                     c.Wd(),
+		Badges:                 []datastore.Datastore{bd},
+		Reports:                []datastore.Datastore{rd},
+		CoverageColor:          c.CoverageColor,
+		CodeToTestRatioColor:   c.CodeToTestRatioColor,
+		TestExecutionTimeColor: c.TestExecutionTimeColor,
+	})
+
+	if err := ctr.collectReports(); err != nil {
+		t.Fatal(err)
+	}
+
+	if want := 1; len(ctr.reports) != want {
+		t.Fatalf("got %v\nwant %v", len(ctr.reports), want)
+	}
+	if got, want := ctr.reports[0].Ref, "refs/heads/main"; got != want {
+		t.Errorf("got %v\nwant %v", got, want)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,8 +168,8 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		// Not fatal: without it the report is stored where the reports of the default
-		// branch go, which is where every report went before refs were separated.
+		// Not fatal, since without it the report is stored where the reports of the
+		// default branch go, which is where every report went before refs were separated.
 		if err := r.DetectRef(ctx); err != nil {
 			cmd.PrintErrf("Skip detecting the ref of the report: %v\n", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,6 +168,12 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
+		// Not fatal: without it the report is stored where the reports of the default
+		// branch go, which is where every report went before refs were separated.
+		if err := r.DetectRef(ctx); err != nil {
+			cmd.PrintErrf("Skip detecting the ref of the report: %v\n", err)
+		}
+
 		if err := c.CoverageConfigReady(); err != nil {
 			cmd.PrintErrf("Skip measuring code coverage: %v\n", err)
 		} else {
@@ -323,7 +329,7 @@ var rootCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			path := fmt.Sprintf("%s/%s/report.json", repo.Owner, repo.Reponame())
+			path := fmt.Sprintf("%s/%s/%s", repo.Owner, repo.Reponame(), report.Filename)
 
 			// Collect filesystem files once for normalizing all loaded reports
 			var gitRoot string

--- a/datastore/artifact/artifact.go
+++ b/datastore/artifact/artifact.go
@@ -16,7 +16,13 @@ import (
 )
 
 const defaultArtifactName = "octocov-report"
-const reportFilename = "report.json"
+const reportFilename = report.Filename
+
+// refSeparator marks off the ref key an artifact name carries. It is not one of the
+// characters an artifact name may not contain, keyRep never produces it, and it needs
+// no escaping where the name travels in a query string, so a reader can split a name on
+// its last occurrence and take what follows as the ref.
+const refSeparator = "@"
 
 var keyRep = strings.NewReplacer(`"`, "_", ":", "_", "<", "_", ">", "_", "|", "_", "*", "_", "?", "_", "\r", "_", "\n", "_", "\\", "_", "/", "_")
 
@@ -40,31 +46,15 @@ func New(gh *gh.Gh, repo, name string, r *report.Report) (*Artifact, error) {
 }
 
 func (a *Artifact) StoreReport(ctx context.Context, r *report.Report) error {
-	switch {
-	case a.repository == r.Repository:
-		return a.Put(ctx, reportFilename, r.Bytes())
-	case strings.HasPrefix(r.Repository, fmt.Sprintf("%s/", a.repository)):
-		a.name = fmt.Sprintf("%s-%s", a.name, keyRep.Replace(r.Key()))
-		return a.Put(ctx, reportFilename, r.Bytes())
-	default:
-		return errors.New("reporting to the artifact can only be sent from the GitHub Actions of the same repository")
-	}
-}
-
-func (a *Artifact) Put(ctx context.Context, path string, content []byte) error {
-	r, err := gh.Parse(a.repository)
+	name, err := a.storeName(r)
 	if err != nil {
 		return err
 	}
-	s := os.Getenv("GITHUB_RUN_ID")
-	if s == "" {
-		return errors.New("env GITHUB_RUN_ID is not set")
-	}
-	runID, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse GITHUB_RUN_ID: %w", err)
-	}
-	return a.gh.PutArtifact(ctx, r.Owner, r.Repo, runID, a.name, path, content)
+	return a.put(ctx, name, reportFilename, r.Bytes())
+}
+
+func (a *Artifact) Put(ctx context.Context, path string, content []byte) error {
+	return a.put(ctx, a.name, path, content)
 }
 
 func (a *Artifact) FS() (fs.FS, error) {
@@ -105,4 +95,38 @@ func (a *Artifact) FS() (fs.FS, error) {
 		}
 	}
 	return &fsys, nil
+}
+
+// storeName returns the artifact name the report is stored under. The report of the
+// default branch keeps the configured name, which is the one FS() looks up, so a
+// comparison and the central mode keep reading the branch they are meant to describe.
+func (a *Artifact) storeName(r *report.Report) (string, error) {
+	name := a.name
+	switch {
+	case a.repository == r.Repository:
+	case strings.HasPrefix(r.Repository, fmt.Sprintf("%s/", a.repository)):
+		name = fmt.Sprintf("%s-%s", name, keyRep.Replace(r.Key()))
+	default:
+		return "", errors.New("reporting to the artifact can only be sent from the GitHub Actions of the same repository")
+	}
+	if k := r.RefKey(); k != "" {
+		name = fmt.Sprintf("%s%s%s", name, refSeparator, keyRep.Replace(k))
+	}
+	return name, nil
+}
+
+func (a *Artifact) put(ctx context.Context, name, path string, content []byte) error {
+	r, err := gh.Parse(a.repository)
+	if err != nil {
+		return err
+	}
+	s := os.Getenv("GITHUB_RUN_ID")
+	if s == "" {
+		return errors.New("env GITHUB_RUN_ID is not set")
+	}
+	runID, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse GITHUB_RUN_ID: %w", err)
+	}
+	return a.gh.PutArtifact(ctx, r.Owner, r.Repo, runID, name, path, content)
 }

--- a/datastore/artifact/artifact_test.go
+++ b/datastore/artifact/artifact_test.go
@@ -1,0 +1,80 @@
+package artifact
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k1LoW/octocov/report"
+)
+
+func TestStoreName(t *testing.T) {
+	tests := []struct {
+		name        string
+		artifact    string
+		repository  string
+		ref         string
+		baseRef     string
+		pullRequest int
+		want        string
+		wantErr     bool
+	}{
+		{"the default branch keeps the configured name", "", "owner/repo", "refs/heads/main", "refs/heads/main", 0, "octocov-report", false},
+		{"a pull request is marked off by its ref", "", "owner/repo", "refs/pull/123/merge", "refs/heads/main", 123, "octocov-report@refs_pull_123", false},
+		{"a branch keeps the separators of its name out of the ref", "", "owner/repo", "refs/heads/feat/x", "refs/heads/main", 0, "octocov-report@refs_heads_feat_x", false},
+		{"a configured name is marked off the same way", "mine", "owner/repo", "refs/pull/123/merge", "refs/heads/main", 123, "mine@refs_pull_123", false},
+		{"a configured name already holding the separator is split on the last one", "mine@v2", "owner/repo", "refs/pull/123/merge", "refs/heads/main", 123, "mine@v2@refs_pull_123", false},
+		{"a sub directory keeps its key ahead of the ref", "", "owner/repo/sub", "refs/pull/123/merge", "refs/heads/main", 123, "octocov-report-sub@refs_pull_123", false},
+		{"a sub directory on the default branch keeps its key alone", "", "owner/repo/sub", "refs/heads/main", "refs/heads/main", 0, "octocov-report-sub", false},
+		{"a report of another repository is refused", "", "other/repo", "refs/heads/main", "refs/heads/main", 0, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_REPOSITORY", "owner/repo")
+			a, err := New(nil, "owner/repo", tt.artifact, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := a.storeName(&report.Report{
+				Repository:  tt.repository,
+				Ref:         tt.ref,
+				BaseRef:     tt.baseRef,
+				PullRequest: tt.pullRequest,
+			})
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("got err: %v", err)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Error("want err")
+				return
+			}
+			if got != tt.want {
+				t.Errorf("got %v\nwant %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStoreNameHasNoInvalidCharacter(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "owner/repo")
+	a, err := New(nil, "owner/repo", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := a.storeName(&report.Report{
+		Repository: "owner/repo",
+		Ref:        `refs/heads/feat/"a:b<c>d|e*f?g\h`,
+		BaseRef:    "refs/heads/main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The characters GitHub refuses in an artifact name, which a ref may hold.
+	for _, c := range []string{`"`, ":", "<", ">", "|", "*", "?", "\r", "\n", `\`, "/"} {
+		if strings.Contains(strings.TrimPrefix(got, "octocov-report"), c) {
+			t.Errorf("got %v\nwant no %q", got, c)
+		}
+	}
+}

--- a/datastore/bq/bq.go
+++ b/datastore/bq/bq.go
@@ -129,13 +129,18 @@ func (b *BQ) FS() (fs.FS, error) {
 	ctx := context.Background()
 	fsys := fstest.MapFS{}
 	t := fmt.Sprintf("`%s.%s`", b.dataset, b.table)
-	// Grouped by ref as well as by repository: without it the newest row of any ref wins,
-	// and a repository that reports from its pull requests would answer a comparison
-	// against its default branch with whichever branch happened to run last.
+	// Grouped by the pull request as well as by the ref, which together are as fine a key
+	// as the one the rows are laid out under below. Grouping by repository alone would let
+	// the newest row of any ref answer for the default branch, and grouping by ref alone
+	// would still collapse a pull_request_target run, where GITHUB_REF holds the base
+	// branch and a pull request shares its ref with the default branch.
 	stmt := `SELECT r.owner, r.repo, r.timestamp, r.raw FROM %s AS r
 INNER JOIN (
-    SELECT owner, repo, ref, MAX(timestamp) AS timestamp FROM %s GROUP BY owner, repo, ref
-) AS l ON r.owner = l.owner AND r.repo = l.repo AND r.ref = l.ref AND l.timestamp = r.timestamp
+    SELECT owner, repo, ref, COALESCE(JSON_VALUE(raw, '$.pull_request'), '') AS pull_request, MAX(timestamp) AS timestamp
+    FROM %s GROUP BY owner, repo, ref, pull_request
+) AS l ON r.owner = l.owner AND r.repo = l.repo AND r.ref = l.ref
+    AND COALESCE(JSON_VALUE(r.raw, '$.pull_request'), '') = l.pull_request
+    AND l.timestamp = r.timestamp
 ORDER BY r.owner, r.repo, r.ref`
 	q := b.client.Query(fmt.Sprintf(stmt, t, t)) //nolint:nosec
 	it, err := q.Read(ctx)

--- a/datastore/bq/bq.go
+++ b/datastore/bq/bq.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/goccy/go-json"
 	"github.com/k1LoW/octocov/gh"
 	"github.com/k1LoW/octocov/report"
 	"github.com/oklog/ulid/v2"
@@ -128,11 +129,14 @@ func (b *BQ) FS() (fs.FS, error) {
 	ctx := context.Background()
 	fsys := fstest.MapFS{}
 	t := fmt.Sprintf("`%s.%s`", b.dataset, b.table)
+	// Grouped by ref as well as by repository: without it the newest row of any ref wins,
+	// and a repository that reports from its pull requests would answer a comparison
+	// against its default branch with whichever branch happened to run last.
 	stmt := `SELECT r.owner, r.repo, r.timestamp, r.raw FROM %s AS r
 INNER JOIN (
-    SELECT owner, repo, MAX(timestamp) AS timestamp FROM %s GROUP BY owner, repo
-) AS l ON r.owner = l.owner AND r.repo = l.repo AND l.timestamp = r.timestamp
-ORDER BY r.owner, r.repo`
+    SELECT owner, repo, ref, MAX(timestamp) AS timestamp FROM %s GROUP BY owner, repo, ref
+) AS l ON r.owner = l.owner AND r.repo = l.repo AND r.ref = l.ref AND l.timestamp = r.timestamp
+ORDER BY r.owner, r.repo, r.ref`
 	q := b.client.Query(fmt.Sprintf(stmt, t, t)) //nolint:nosec
 	it, err := q.Read(ctx)
 	if err != nil {
@@ -147,7 +151,19 @@ ORDER BY r.owner, r.repo`
 		if err != nil {
 			return nil, err
 		}
-		path := fmt.Sprintf("%s/%s/report.json", rr.Owner, rr.Repo)
+		path := fmt.Sprintf("%s/%s/%s", rr.Owner, rr.Repo, report.Filename)
+		rt := &report.Report{}
+		if err := json.Unmarshal([]byte(rr.Raw), rt); err == nil {
+			if k := rt.RefKey(); k != "" {
+				path = fmt.Sprintf("%s/%s/%s/%s", rr.Owner, rr.Repo, k, report.Filename)
+			}
+		}
+		// Rows written before the ref was recorded all resolve to the same path, so the
+		// newest of them is the one kept, as it was when the query returned only one row
+		// per repository.
+		if e, ok := fsys[path]; ok && e.ModTime.After(rr.Timestamp) {
+			continue
+		}
 		fsys[path] = &fstest.MapFile{
 			Data:    []byte(rr.Raw),
 			Mode:    fs.ModePerm,

--- a/datastore/gcs/gcs.go
+++ b/datastore/gcs/gcs.go
@@ -3,7 +3,7 @@ package gcs
 import (
 	"context"
 	"io/fs"
-	"path/filepath"
+	"path"
 
 	"cloud.google.com/go/storage"
 	"github.com/k1LoW/octocov/report"
@@ -29,8 +29,11 @@ func (g *GCS) StoreReport(ctx context.Context, r *report.Report) error {
 	return g.Put(ctx, path, r.Bytes())
 }
 
-func (g *GCS) Put(ctx context.Context, path string, content []byte) error {
-	o := filepath.Join(g.prefix, path)
+func (g *GCS) Put(ctx context.Context, p string, content []byte) error {
+	// path.Join rather than filepath.Join, since an object name is slash separated on
+	// every OS, and the separator filepath would pick on Windows would store the report
+	// under a name nothing reads back.
+	o := path.Join(g.prefix, p)
 	w := g.client.Bucket(g.bucket).Object(o).NewWriter(ctx)
 	if _, err := w.Write(content); err != nil {
 		return err
@@ -47,7 +50,7 @@ type FS struct {
 }
 
 func (fsys *FS) Open(name string) (fs.File, error) { //nostyle:recvnames
-	return fsys.gscfs.Open(filepath.Join(fsys.prefix, name))
+	return fsys.gscfs.Open(path.Join(fsys.prefix, name))
 }
 
 func (g *GCS) FS() (fs.FS, error) {

--- a/datastore/gcs/gcs.go
+++ b/datastore/gcs/gcs.go
@@ -2,7 +2,6 @@ package gcs
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"path/filepath"
 
@@ -26,7 +25,7 @@ func New(client *storage.Client, bucket, prefix string) (*GCS, error) {
 }
 
 func (g *GCS) StoreReport(ctx context.Context, r *report.Report) error {
-	path := fmt.Sprintf("%s/report.json", r.Repository)
+	path := r.StorePath()
 	return g.Put(ctx, path, r.Bytes())
 }
 

--- a/datastore/github/github.go
+++ b/datastore/github/github.go
@@ -29,7 +29,7 @@ func New(gh *gh.Gh, r, b, prefix string) (*Github, error) {
 }
 
 func (g *Github) StoreReport(ctx context.Context, r *report.Report) error {
-	path := fmt.Sprintf("%s/report.json", r.Repository)
+	path := r.StorePath()
 	g.from = r.Repository
 	return g.Put(ctx, path, r.Bytes())
 }

--- a/datastore/github/github.go
+++ b/datastore/github/github.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 
 	"github.com/k1LoW/ghfs"
 	"github.com/k1LoW/octocov/gh"
@@ -34,14 +34,17 @@ func (g *Github) StoreReport(ctx context.Context, r *report.Report) error {
 	return g.Put(ctx, path, r.Bytes())
 }
 
-func (g *Github) Put(ctx context.Context, path string, content []byte) error {
+func (g *Github) Put(ctx context.Context, p string, content []byte) error {
 	branch := g.branch
 	message := fmt.Sprintf("Store coverage report of %s", g.from)
 	repo, err := gh.Parse(g.repository)
 	if err != nil {
 		return err
 	}
-	cp := filepath.Join(g.prefix, path)
+	// path.Join rather than filepath.Join, since a path inside a git repository is slash
+	// separated on every OS, and the separator filepath would pick on Windows would commit
+	// the report under a name nothing reads back.
+	cp := path.Join(g.prefix, p)
 	return g.gh.PushContent(ctx, repo.Owner, repo.Repo, branch, string(content), cp, message)
 }
 

--- a/datastore/local/local.go
+++ b/datastore/local/local.go
@@ -36,7 +36,7 @@ func (l *Local) Root() string {
 }
 
 func (l *Local) StoreReport(ctx context.Context, r *report.Report) error {
-	path := fmt.Sprintf("%s/report.json", r.Repository)
+	path := r.StorePath()
 	return l.Put(ctx, path, r.Bytes())
 }
 

--- a/datastore/local/local_test.go
+++ b/datastore/local/local_test.go
@@ -41,19 +41,37 @@ func TestRoot(t *testing.T) {
 
 func TestStoreReport(t *testing.T) {
 	ctx := context.Background()
-	root := t.TempDir()
-	l, err := New(root)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name        string
+		ref         string
+		baseRef     string
+		pullRequest int
+		want        []string
+	}{
+		{"the default branch is stored where comparisons read it", "refs/heads/main", "refs/heads/main", 0, []string{"owner", "repo", "report.json"}},
+		{"a report without a base ref is stored there too", "", "", 0, []string{"owner", "repo", "report.json"}},
+		{"a pull request is stored beside it", "refs/pull/123/merge", "refs/heads/main", 123, []string{"owner", "repo", "refs", "pull", "123", "report.json"}},
+		{"a branch is stored beside it", "refs/heads/feat/x", "refs/heads/main", 0, []string{"owner", "repo", "refs", "heads", "feat", "x", "report.json"}},
 	}
-	r := &report.Report{
-		Repository: "owner/repo",
-	}
-	if err := l.StoreReport(ctx, r); err != nil {
-		t.Fatal(err)
-	}
-	want := filepath.Join(l.Root(), "owner", "repo", "report.json")
-	if _, err := os.Lstat(want); err != nil {
-		t.Errorf("%s does not exist", want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := New(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := &report.Report{
+				Repository:  "owner/repo",
+				Ref:         tt.ref,
+				BaseRef:     tt.baseRef,
+				PullRequest: tt.pullRequest,
+			}
+			if err := l.StoreReport(ctx, r); err != nil {
+				t.Fatal(err)
+			}
+			want := filepath.Join(append([]string{l.Root()}, tt.want...)...)
+			if _, err := os.Lstat(want); err != nil {
+				t.Errorf("%s does not exist", want)
+			}
+		})
 	}
 }

--- a/datastore/s3/s3.go
+++ b/datastore/s3/s3.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io/fs"
-	"path/filepath"
+	"path"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -41,8 +41,11 @@ func (s *S3) StoreReport(ctx context.Context, r *report.Report) error {
 	return s.Put(ctx, path, r.Bytes())
 }
 
-func (s *S3) Put(ctx context.Context, path string, content []byte) error {
-	key := filepath.Join(s.prefix, path)
+func (s *S3) Put(ctx context.Context, p string, content []byte) error {
+	// path.Join rather than filepath.Join, since an object key is slash separated on
+	// every OS, and the separator filepath would pick on Windows would store the report
+	// under a key nothing reads back.
+	key := path.Join(s.prefix, p)
 	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:        &s.bucket,
 		Key:           &key,

--- a/datastore/s3/s3.go
+++ b/datastore/s3/s3.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/fs"
 	"path/filepath"
 
@@ -38,7 +37,7 @@ func New(client Client, bucket, prefix string) (*S3, error) {
 }
 
 func (s *S3) StoreReport(ctx context.Context, r *report.Report) error {
-	path := fmt.Sprintf("%s/report.json", r.Repository)
+	path := r.StorePath()
 	return s.Put(ctx, path, r.Bytes())
 }
 

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -218,6 +218,12 @@ func (g *Gh) DetectCurrentJobID(ctx context.Context, owner, repo string) (int64,
 }
 
 func (g *Gh) DetectCurrentBranch(ctx context.Context) (string, error) {
+	// GITHUB_HEAD_REF is set only for the pull request events, and on pull_request_target
+	// GITHUB_REF names the base branch rather than the merge ref, so reading GITHUB_REF
+	// first would report the base branch as the branch being built.
+	if h := os.Getenv("GITHUB_HEAD_REF"); h != "" {
+		return h, nil
+	}
 	splitted := strings.SplitN(os.Getenv("GITHUB_REF"), "/", 3) // refs/pull/8/head or refs/heads/branch/branch/name
 	if len(splitted) < 3 {
 		return "", fmt.Errorf("env %s is not set", "GITHUB_REF")
@@ -225,10 +231,21 @@ func (g *Gh) DetectCurrentBranch(ctx context.Context) (string, error) {
 	if strings.Contains(os.Getenv("GITHUB_REF"), "refs/heads/") {
 		return splitted[2], nil
 	}
-	if os.Getenv("GITHUB_HEAD_REF") == "" {
-		return "", fmt.Errorf("env %s is not set", "GITHUB_HEAD_REF")
+	return "", fmt.Errorf("env %s is not set", "GITHUB_HEAD_REF")
+}
+
+// DetectCurrentBaseRef returns the ref the current run is to be compared against: the
+// base branch of the pull request when the run is on one, and the default branch
+// otherwise.
+func (g *Gh) DetectCurrentBaseRef(ctx context.Context, owner, repo string) (string, error) {
+	if b := os.Getenv("GITHUB_BASE_REF"); b != "" {
+		return fmt.Sprintf("refs/heads/%s", b), nil
 	}
-	return os.Getenv("GITHUB_HEAD_REF"), nil
+	b, err := g.FetchDefaultBranch(ctx, owner, repo)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("refs/heads/%s", b), nil
 }
 
 // ErrNotPullRequest marks the failures of DetectCurrentPullRequestNumber that only mean the run
@@ -251,7 +268,12 @@ func (g *Gh) DetectCurrentPullRequestNumber(ctx context.Context, owner, repo str
 		prNumber := splitted[2]
 		return strconv.Atoi(prNumber)
 	}
-	b := strings.Join(splitted[2:], "/")
+	// Not GITHUB_REF, which on pull_request_target holds the base branch and would send
+	// the search after whichever pull request has the base branch as its head.
+	b, err := g.DetectCurrentBranch(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", ErrNotPullRequest, err)
+	}
 	l, _, err := g.client.PullRequests.List(ctx, owner, repo, &github.PullRequestListOptions{
 		State: "open",
 	})

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -234,8 +234,8 @@ func (g *Gh) DetectCurrentBranch(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("env %s is not set", "GITHUB_HEAD_REF")
 }
 
-// DetectCurrentBaseRef returns the ref the current run is to be compared against: the
-// base branch of the pull request when the run is on one, and the default branch
+// DetectCurrentBaseRef returns the ref the current run is to be compared against, which
+// is the base branch of the pull request when the run is on one, and the default branch
 // otherwise.
 func (g *Gh) DetectCurrentBaseRef(ctx context.Context, owner, repo string) (string, error) {
 	if b := os.Getenv("GITHUB_BASE_REF"); b != "" {

--- a/gh/gh_test.go
+++ b/gh/gh_test.go
@@ -93,8 +93,8 @@ func TestDetectCurrentBranch(t *testing.T) {
 		wantErr         bool
 	}{
 		{"refs/pull/8/head", "", "", true},
-		// The shape of a pull_request_target run: GITHUB_REF names the base branch and
-		// only GITHUB_HEAD_REF names the branch being built.
+		// The shape of a pull_request_target run, where GITHUB_REF names the base branch
+		// and only GITHUB_HEAD_REF names the branch being built.
 		{"refs/heads/name", "mybranch", "mybranch", false},
 		{"refs/heads/branch/branch/name", "", "branch/branch/name", false},
 		{"refs/pull/8/head", "mybranch", "mybranch", false},
@@ -143,8 +143,8 @@ func TestDetectCurrentPullRequestNumber(t *testing.T) {
 	ctx := context.TODO()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Per case: the mock serves each matched request once, and more than one case
-			// now reaches the pull request listing.
+			// Per case, since the mock serves each matched request once and more than one
+			// case now reaches the pull request listing.
 			mg := mockedGh(t)
 			t.Setenv("GITHUB_PULL_REQUEST_NUMBER", tt.GITHUB_PULL_REQUEST_NUMBER)
 			t.Setenv("GITHUB_REF", tt.GITHUB_REF)

--- a/gh/gh_test.go
+++ b/gh/gh_test.go
@@ -93,7 +93,9 @@ func TestDetectCurrentBranch(t *testing.T) {
 		wantErr         bool
 	}{
 		{"refs/pull/8/head", "", "", true},
-		{"refs/heads/name", "mybranch", "name", false},
+		// The shape of a pull_request_target run: GITHUB_REF names the base branch and
+		// only GITHUB_HEAD_REF names the branch being built.
+		{"refs/heads/name", "mybranch", "mybranch", false},
 		{"refs/heads/branch/branch/name", "", "branch/branch/name", false},
 		{"refs/pull/8/head", "mybranch", "mybranch", false},
 	}
@@ -122,23 +124,31 @@ func TestDetectCurrentBranch(t *testing.T) {
 
 func TestDetectCurrentPullRequestNumber(t *testing.T) {
 	tests := []struct {
+		name                       string
 		GITHUB_PULL_REQUEST_NUMBER string
 		GITHUB_REF                 string
+		GITHUB_HEAD_REF            string
 		want                       int
 		wantErr                    bool
 	}{
-		{"", "refs/pull/8/head", 8, false},
-		{"", "refs/heads/branch/branch/name", 13, false},
-		{"", "refs/8", 0, true},
-		{"8", "", 8, false},
-		{"str", "", 0, true},
+		{"pull request ref", "", "refs/pull/8/head", "", 8, false},
+		{"branch ref", "", "refs/heads/branch/branch/name", "", 13, false},
+		{"malformed ref", "", "refs/8", "", 0, true},
+		{"number from the environment", "8", "", "", 8, false},
+		{"unparsable number", "str", "", "", 0, true},
+		// On pull_request_target GITHUB_REF names the base branch, so the search has to
+		// go after the head ref rather than after whatever GITHUB_REF holds.
+		{"base branch ref with a head ref", "", "refs/heads/main", "branch/branch/name", 13, false},
 	}
 	ctx := context.TODO()
-	mg := mockedGh(t)
 	for _, tt := range tests {
-		t.Run(tt.GITHUB_REF, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
+			// Per case: the mock serves each matched request once, and more than one case
+			// now reaches the pull request listing.
+			mg := mockedGh(t)
 			t.Setenv("GITHUB_PULL_REQUEST_NUMBER", tt.GITHUB_PULL_REQUEST_NUMBER)
 			t.Setenv("GITHUB_REF", tt.GITHUB_REF)
+			t.Setenv("GITHUB_HEAD_REF", tt.GITHUB_HEAD_REF)
 			got, err := mg.DetectCurrentPullRequestNumber(ctx, "owner", "repo")
 			if err != nil {
 				if !tt.wantErr {
@@ -395,6 +405,7 @@ func TestDetectCurrentPullRequestNumberSkipsForkPR(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GITHUB_PULL_REQUEST_NUMBER", "")
 			t.Setenv("GITHUB_REF", tt.GITHUB_REF)
+			t.Setenv("GITHUB_HEAD_REF", "")
 			t.Setenv("GITHUB_TOKEN", "dummy")
 
 			mockedHTTPClient := mock.NewMockedHTTPClient( //nostyle:funcfmt
@@ -716,6 +727,7 @@ func TestDetectCurrentPullRequestNumberClassifiesFailures(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GITHUB_PULL_REQUEST_NUMBER", "")
 			t.Setenv("GITHUB_REF", tt.GITHUB_REF)
+			t.Setenv("GITHUB_HEAD_REF", "")
 			_, err := mg.DetectCurrentPullRequestNumber(ctx, "owner", "repo")
 			if err == nil {
 				t.Fatal("want err")
@@ -729,6 +741,7 @@ func TestDetectCurrentPullRequestNumberClassifiesFailures(t *testing.T) {
 	t.Run("a malformed pull request number is a real failure", func(t *testing.T) {
 		t.Setenv("GITHUB_PULL_REQUEST_NUMBER", "not-a-number")
 		t.Setenv("GITHUB_REF", "")
+		t.Setenv("GITHUB_HEAD_REF", "")
 		_, err := mg.DetectCurrentPullRequestNumber(ctx, "owner", "repo")
 		if err == nil {
 			t.Fatal("want err")

--- a/report/report.go
+++ b/report/report.go
@@ -29,6 +29,9 @@ import (
 	"golang.org/x/text/number"
 )
 
+// Filename is the name the report is stored under in every datastore.
+const Filename = "report.json"
+
 const filesHideMin = 30
 const filesSkipMax = 100
 
@@ -40,6 +43,8 @@ type Report struct {
 	Repository        string             `json:"repository"`
 	Ref               string             `json:"ref"`
 	Commit            string             `json:"commit"`
+	PullRequest       int                `json:"pull_request,omitempty"`
+	BaseRef           string             `json:"base_ref,omitempty"`
 	Coverage          *coverage.Coverage `json:"coverage,omitempty"`
 	CodeToTestRatio   *ratio.Ratio       `json:"code_to_test_ratio,omitempty"`
 	TestExecutionTime *float64           `json:"test_execution_time,omitempty"`
@@ -83,6 +88,87 @@ func New(ownerrepo string, opts ...Option) (*Report, error) {
 		Timestamp:  time.Now().UTC(),
 		opts:       o,
 	}, nil
+}
+
+// DetectRef fills in the pull request number and the base ref of the current run.
+// Both are recorded in the report and decide where it is stored, so that a report of
+// a ref other than the default branch does not overwrite the one that comparisons and
+// the central mode read.
+func (r *Report) DetectRef(ctx context.Context) error {
+	if r.Repository == "" {
+		return fmt.Errorf("env %s is not set", "GITHUB_REPOSITORY")
+	}
+	repo, err := gh.Parse(r.Repository)
+	if err != nil {
+		return err
+	}
+	g, err := gh.New()
+	if err != nil {
+		return err
+	}
+	// Before the pull request number, so that a run whose pull request cannot be resolved
+	// still knows its ref is not the default branch and keeps its report off the one the
+	// comparisons read.
+	base, err := g.DetectCurrentBaseRef(ctx, repo.Owner, repo.Repo)
+	if err != nil {
+		return err
+	}
+	r.BaseRef = base
+	n, err := g.DetectCurrentPullRequestNumber(ctx, repo.Owner, repo.Repo)
+	switch {
+	case err == nil:
+		r.PullRequest = n
+	case errors.Is(err, gh.ErrNotPullRequest):
+	default:
+		return err
+	}
+	return nil
+}
+
+// RefKey returns the key that separates this report from the reports of other refs in
+// a datastore. The default branch keeps the empty key, which is the single location
+// every report was stored at before refs were separated, so reports already stored
+// there stay the ones that comparisons are made against. A report that predates
+// BaseRef carries no way to tell its ref apart from the default branch, so it keeps
+// the empty key too rather than being moved somewhere its readers do not look.
+func (r *Report) RefKey() string {
+	if r.PullRequest > 0 {
+		return fmt.Sprintf("refs/pull/%d", r.PullRequest)
+	}
+	ref := NormalizeRef(r.Ref)
+	base := NormalizeRef(r.BaseRef)
+	if ref == "" || base == "" || ref == base {
+		return ""
+	}
+	return ref
+}
+
+// StorePath returns the path of the report file within a datastore.
+func (r *Report) StorePath() string {
+	if k := r.RefKey(); k != "" {
+		return fmt.Sprintf("%s/%s/%s", r.Repository, k, Filename)
+	}
+	return fmt.Sprintf("%s/%s", r.Repository, Filename)
+}
+
+// NormalizeRef expands a bare branch name to its full ref path and drops the /merge
+// and /head suffixes GITHUB_REF carries on pull request events, neither of which
+// identifies a ref of its own.
+func NormalizeRef(ref string) string {
+	if ref == "" {
+		return ""
+	}
+	if !strings.HasPrefix(ref, "refs/") {
+		return fmt.Sprintf("refs/heads/%s", ref)
+	}
+	if rest, ok := strings.CutPrefix(ref, "refs/pull/"); ok {
+		n, _, _ := strings.Cut(rest, "/")
+		if n == "" {
+			return ""
+		}
+		return fmt.Sprintf("refs/pull/%s", n)
+	}
+	return ref
 }
 
 func (r *Report) Title() string {

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -631,5 +632,109 @@ func TestConvertFormat(t *testing.T) {
 				t.Error(diff)
 			}
 		})
+	}
+}
+
+func TestNormalizeRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{"", ""},
+		{"refs/heads/main", "refs/heads/main"},
+		{"refs/heads/feat/x", "refs/heads/feat/x"},
+		{"refs/tags/v1.0.0", "refs/tags/v1.0.0"},
+		{"main", "refs/heads/main"},
+		{"feat/x", "refs/heads/feat/x"},
+		{"refs/pull/123/merge", "refs/pull/123"},
+		{"refs/pull/123/head", "refs/pull/123"},
+		{"refs/pull/123", "refs/pull/123"},
+		{"refs/pull/", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			got := NormalizeRef(tt.ref)
+			if got != tt.want {
+				t.Errorf("got %v\nwant %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		ref         string
+		baseRef     string
+		pullRequest int
+		want        string
+	}{
+		{"the default branch keeps the key every report was stored under", "refs/heads/main", "refs/heads/main", 0, ""},
+		{"a branch of its own is separated", "refs/heads/feat/x", "refs/heads/main", 0, "refs/heads/feat/x"},
+		{"a tag is separated", "refs/tags/v1.0.0", "refs/heads/main", 0, "refs/tags/v1.0.0"},
+		{"a pull request is keyed by its number", "refs/pull/123/merge", "refs/heads/main", 123, "refs/pull/123"},
+		{"a pull request outranks a ref naming the base branch", "refs/heads/main", "refs/heads/main", 123, "refs/pull/123"},
+		{"a pull request ref is read when the number was not detected", "refs/pull/123/merge", "refs/heads/main", 0, "refs/pull/123"},
+		{"a report predating the base ref stays where its readers look", "refs/heads/feat/x", "", 0, ""},
+		{"a bare branch name is compared against the base branch", "main", "refs/heads/main", 0, ""},
+		{"a report without a ref stays where its readers look", "", "refs/heads/main", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Report{
+				Repository:  "owner/repo",
+				Ref:         tt.ref,
+				BaseRef:     tt.baseRef,
+				PullRequest: tt.pullRequest,
+			}
+			got := r.RefKey()
+			if got != tt.want {
+				t.Errorf("got %v\nwant %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStorePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		repository  string
+		ref         string
+		baseRef     string
+		pullRequest int
+		want        string
+	}{
+		{"default branch", "owner/repo", "refs/heads/main", "refs/heads/main", 0, "owner/repo/report.json"},
+		{"pull request", "owner/repo", "refs/pull/123/merge", "refs/heads/main", 123, "owner/repo/refs/pull/123/report.json"},
+		{"branch", "owner/repo", "refs/heads/feat/x", "refs/heads/main", 0, "owner/repo/refs/heads/feat/x/report.json"},
+		{"sub directory of a repository", "owner/repo/sub", "refs/pull/123/merge", "refs/heads/main", 123, "owner/repo/sub/refs/pull/123/report.json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Report{
+				Repository:  tt.repository,
+				Ref:         tt.ref,
+				BaseRef:     tt.baseRef,
+				PullRequest: tt.pullRequest,
+			}
+			got := r.StorePath()
+			if got != tt.want {
+				t.Errorf("got %v\nwant %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBytesOmitsUnsetRefFields(t *testing.T) {
+	r := &Report{
+		Repository: "owner/repo",
+		Ref:        "refs/heads/main",
+		Commit:     "1234567890",
+	}
+	got := string(r.Bytes())
+	for _, k := range []string{"pull_request", "base_ref"} {
+		if strings.Contains(got, k) {
+			t.Errorf("got %v\nwant no %s", got, k)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **The datastores held one report per repository.** The comparison a pull request shows was against the default branch only because `report.if: is_default_branch` kept every other run from writing there. Dropping the condition, which is what it takes for the coverage of a pull request to be readable later, made the comparison read whichever branch happened to run last instead, and the same report is what the central index and the badges are built from.
- **The report now records the pull request number and the base ref, and a ref key is derived from them.** The default branch keeps the empty key, so it stays at the path and the artifact name `diff.datastores:` and the central mode already read, and every other ref is stored beside it. A configuration without the condition stops overwriting the report of the default branch, and one that keeps it stores in the same place it always did.

```
owner/repo/report.json                      # the default branch, as before
owner/repo/refs/pull/123/report.json
owner/repo/refs/heads/feat/x/report.json

octocov-report                              # the default branch, as before
octocov-report@refs_pull_123
octocov-report@refs_heads_feat_x
```

- **`@` marks off the ref in an artifact name.** It is not among the characters an artifact name may not hold, `keyRep` never produces it, and it survives a query string unescaped, so a reader can split a name on its last occurrence and take what follows as the ref. Paths carry the ref as `refs/...` directly, and only the artifact name replaces the separators, so both come from one string.
- **A report written before `base_ref` existed keeps the empty key.** Such a report carries no way to tell its ref from the default branch, so moving it somewhere its readers do not look would be worse than leaving it where it has always been. That is what keeps the central re-report and any datastore filled by an older octocov working.
- **BigQuery needed the same separation on the way out.** Its query took the newest row per repository across all refs, which the pull request rows would win. It now groups by the pull request as well as by the ref, which together are as fine a key as the one the rows are laid out under. Grouping by ref alone was not enough, because on `pull_request_target` a pull request writes a row carrying the ref of the base branch. The rows themselves were already per-run, so nothing about writing changed.
- **The object keys are composed with `path.Join` now.** An S3 key, a GCS object name and a path inside a git repository are slash separated on every OS, but all three used `filepath.Join`, which joins with a backslash on Windows. This is older than the ref keys, which only make more of the string separators, and it is fixed here because the reader composed its lookups the same way and so agreed with the writer only by both being wrong.

## Behaviour change for an existing configuration

`report.if: is_default_branch` keeps storing to the same place it always did, so for a workflow triggered by `push` and `pull_request` the storage layout, the comparison and the central index are all unchanged. Two things do change even there.

- **`is_default_branch` is now false on a `pull_request_target` run, where it used to be true.** `GITHUB_REF` names the base branch on that event, so `DetectCurrentBranch` reported the base branch as the branch being built, and every such run counted as the default branch. `GITHUB_HEAD_REF` is set only for the pull request events and always names the head branch, so it is read first, and `DetectCurrentPullRequestNumber` follows it rather than searching for a pull request whose head is the base branch. A `pull_request_target` workflow that gates `report:` or `push:` on `is_default_branch` was storing the report of a pull request as the one of the default branch, and pushing generated files from it. It stops doing both. Nothing changes on `pull_request`, where `GITHUB_REF` is the merge ref and already fell through to `GITHUB_HEAD_REF`.
- **`base_ref` now appears in the stored `report.json`**, including the one of the default branch, since the ref key is derived from it. It is an added field with `omitempty`, so an older octocov and any other reader ignore it.

Detecting the ref costs one extra API call per run, next to the ones `CheckIf` already makes, and it is not fatal. A run that cannot resolve it stores where the reports of the default branch go, which is where every report went before.

## Worth weighing

- `github://` stores each report as a commit that stays, so a repository reporting from every run accumulates them. The README now says so, and says `report.if: is_default_branch` is what to reach for there.
- The `.octocov.yml` of this repository drops the condition, which made the second octocov step of `Test` delete the artifact the first one wrote, a write a fork's token does not carry. That step never reached the delete from a pull request before, because the condition held the storing back entirely, so it is now gated on the event. The re-upload check keeps running exactly where it has been running.

`octocov.dev` can already show a stored report given its artifact name, which is what this makes exist for a pull request.
