### PR TITLE
fix: let the generated config report from every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@ comment:
 summary:
   if: true
 report:
-  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}
 diff:

--- a/config/template/.octocov.yml.tmpl
+++ b/config/template/.octocov.yml.tmpl
@@ -12,6 +12,5 @@ comment:
 summary:
   if: true
 report:
-  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}

--- a/config/testdata/base_octocov.yml.golden
+++ b/config/testdata/base_octocov.yml.golden
@@ -11,6 +11,5 @@ comment:
 summary:
   if: true
 report:
-  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}

--- a/config/testdata/go_octocov.yml.golden
+++ b/config/testdata/go_octocov.yml.golden
@@ -17,6 +17,5 @@ comment:
 summary:
   if: true
 report:
-  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
## Summary

- **`octocov init` still writes `report.if: is_default_branch`.** #720 made the report of a ref other than the default branch store beside the one of the default branch rather than over it, and dropped the condition from the `.octocov.yml` of this repository, but the template the command writes was left alone. A repository started from it stores nothing from its pull requests, so their coverage is not there to read afterwards, which is the thing that change was for.
- **Nothing about the pull request comment changes.** `diff.datastores:` reads the report of the default branch whether or not the pull requests report as well, so the comparison a generated configuration shows is the same one it showed before.
- The README example that carried the condition follows. The one under `report.if:` keeps it, since that section is about what the condition does, and the `push.if:`, `coverage.if:` and `codeToTestRatio.if:` examples are untouched.

The two `octocov init` goldens move with the template.