### PR TITLE
feat: link the coverage values to octocov.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ diff:
 
 ![img](docs/comment_with_diff.png)
 
+When the report is stored in a GitHub Actions artifact, the coverage values of the comment link to [octocov.dev](https://octocov.dev/), where the stored report can be browsed. The overall coverage opens the report of the pull request and the coverage of each file opens that file, while the file names keep pointing at the source on GitHub. Set `comment.hideCoverageLink:` ( or the same key under `summary:` or `body:` ) to render them as plain values again.
+
 ### Check for acceptable score
 
 By setting `coverage.acceptable:`, the condition of acceptable coverage is specified.
@@ -718,6 +720,15 @@ comment:
   hideFooterLink: true
 ```
 
+### `comment.hideCoverageLink:`
+
+Hide the [octocov.dev](https://octocov.dev/) links the coverage values carry.
+
+```yaml
+comment:
+  hideCoverageLink: true
+```
+
 ### `comment.deletePrevious:`
 
 Delete previous code metrics report comments instead of hiding them
@@ -773,6 +784,15 @@ summary:
   hideFooterLink: true
 ```
 
+### `summary.hideCoverageLink:`
+
+Hide the [octocov.dev](https://octocov.dev/) links the coverage values carry.
+
+```yaml
+summary:
+  hideCoverageLink: true
+```
+
 ### `summary.message:`
 
 Add message to report.
@@ -805,6 +825,15 @@ Hide footer [octocov](https://github.com/k1LoW/octocov) link.
 ```yaml
 body:
   hideFooterLink: true
+```
+
+### `body.hideCoverageLink:`
+
+Hide the [octocov.dev](https://octocov.dev/) links the coverage values carry.
+
+```yaml
+body:
+  hideCoverageLink: true
 ```
 
 ### `body.message:`

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ diff:
 
 ![img](docs/comment_with_diff.png)
 
-When the report is stored in a GitHub Actions artifact, the coverage values of the comment link to [octocov.dev](https://octocov.dev/), where the stored report can be browsed. The overall coverage opens the report of the pull request and the coverage of each file opens that file, while the file names keep pointing at the source on GitHub. Set `comment.hideCoverageLink:` ( or the same key under `summary:` or `body:` ) to render them as plain values again.
+When the report is stored in a GitHub Actions artifact, the coverage values of the comment link to [octocov.dev](https://octocov.dev/), where the stored report can be browsed. Each overall coverage opens the report of the ref it describes, so the compared column opens the default branch and the current one opens the pull request, and the coverage of each file opens that file. The file names keep pointing at the source on GitHub. Set `comment.hideCoverageLink:` ( or the same key under `summary:` or `body:` ) to render them as plain values again.
 
 ### Check for acceptable score
 

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -44,8 +44,9 @@ func commentReport(ctx context.Context, c *config.Config, content, key string) e
 
 // createReportContent renders the report for one of the pull request outputs. files is the
 // changed file list, fetched by the caller so that the three outputs and the patch coverage
-// measurement share one paginated fetch instead of repeating it.
-func createReportContent(c *config.Config, r, rPrev *report.Report, files []*gh.PullRequestFile, message string, hideFooterLink bool) (string, error) {
+// measurement share one paginated fetch instead of repeating it. v links the coverage cells
+// to the pages that browse the stored report, and is nil when there are none to link to.
+func createReportContent(c *config.Config, r, rPrev *report.Report, files []*gh.PullRequestFile, message string, hideFooterLink bool, v *report.Viewer) (string, error) {
 	footer := "Reported by [octocov](https://github.com/k1LoW/octocov)"
 	if hideFooterLink {
 		footer = "Reported by octocov"
@@ -56,7 +57,7 @@ func createReportContent(c *config.Config, r, rPrev *report.Report, files []*gh.
 	)
 	if rPrev != nil {
 		d := r.Compare(rPrev)
-		table = d.Table()
+		table = d.Table(v)
 		relWd := c.Root()
 		if c.GitRoot != "" {
 			if rw, err := filepath.Rel(c.GitRoot, c.Root()); err == nil {
@@ -66,13 +67,13 @@ func createReportContent(c *config.Config, r, rPrev *report.Report, files []*gh.
 		if relWd == "." {
 			relWd = ""
 		}
-		fileTable = d.FileCoveragesTable(files, relWd)
+		fileTable = d.FileCoveragesTable(files, relWd, v)
 		for _, s := range d.CustomMetrics {
 			customTables = append(customTables, s.Table(), s.MetadataTable())
 		}
 	} else {
-		table = r.Table()
-		fileTable = r.FileCoveragesTable(files)
+		table = r.Table(v)
+		fileTable = r.FileCoveragesTable(files, v)
 		for _, s := range r.CustomMetrics {
 			customTables = append(customTables, s.Table(), s.MetadataTable())
 		}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -101,7 +101,9 @@ var diffCmd = &cobra.Command{
 			// ways it can be empty was hit instead of leaving --patch looking silently broken.
 			// None of the wordings names a pull request, since the changed files can equally
 			// have come from the default branch comparison fetchPullRequestFiles falls back to.
-			switch table := dr.FileCoveragesTable(files, ""); {
+			// No viewer, since this table is printed to a terminal, where a markdown link
+			// is noise.
+			switch table := dr.FileCoveragesTable(files, "", nil); {
 			case table != "":
 				fmt.Fprintln(os.Stdout, table)
 			case dr.Coverage == nil:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -413,7 +413,7 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Comment.Message, c.Comment.HideFooterLink)
+				content, err := createReportContent(c, r, rPrev, files, c.Comment.Message, c.Comment.HideFooterLink, coverageViewer(c, r, c.Comment.HideCoverageLink))
 				if err != nil {
 					return err
 				}
@@ -442,7 +442,7 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Summary.Message, c.Summary.HideFooterLink)
+				content, err := createReportContent(c, r, rPrev, files, c.Summary.Message, c.Summary.HideFooterLink, coverageViewer(c, r, c.Summary.HideCoverageLink))
 				if err != nil {
 					return err
 				}
@@ -471,7 +471,7 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Body.Message, c.Body.HideFooterLink)
+				content, err := createReportContent(c, r, rPrev, files, c.Body.Message, c.Body.HideFooterLink, coverageViewer(c, r, c.Body.HideCoverageLink))
 				if err != nil {
 					return err
 				}
@@ -645,6 +645,23 @@ func init() {
 	rootCmd.Flags().StringVarP(&configPath, "config", "", "", "config file path")
 	rootCmd.Flags().StringVarP(&reportPath, "report", "r", "", "coverage report file path")
 	rootCmd.Flags().BoolVarP(&createTable, "create-bq-table", "", false, "create table of BigQuery dataset")
+}
+
+// coverageViewer returns the viewer the coverage cells of one output link to. The pages it
+// points at read the report out of a GitHub Actions artifact, so a configuration storing
+// the report anywhere else, or none at all, gets no links rather than dead ones.
+func coverageViewer(c *config.Config, r *report.Report, hide bool) *report.Viewer {
+	if hide {
+		return nil
+	}
+	if err := c.ReportConfigTargetReady(); err != nil {
+		return nil
+	}
+	name, ok := datastore.ArtifactName(c.Report.Datastores, r)
+	if !ok {
+		return nil
+	}
+	return report.NewViewer(name)
 }
 
 func reportToDatastores(ctx context.Context, c *config.Config, datastores []string, r *report.Report) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -397,6 +397,18 @@ var rootCmd = &cobra.Command{
 			return fetchPullRequestFiles(ctx, cmd, c.Repository)
 		})
 
+		// Resolved at most once, since the readiness check inside reaches the API and the
+		// three outputs share the answer.
+		storedArtifact := sync.OnceValue(func() *report.Viewer {
+			return storedArtifactViewer(c, r)
+		})
+		coverageViewer := func(hide bool) *report.Viewer {
+			if hide {
+				return nil
+			}
+			return storedArtifact()
+		}
+
 		// Comment report to pull request
 		if err := c.CommentConfigReady(); err != nil {
 			cmd.PrintErrf("Skip commenting report to pull request: %v\n", err)
@@ -413,7 +425,7 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Comment.Message, c.Comment.HideFooterLink, coverageViewer(c, r, c.Comment.HideCoverageLink))
+				content, err := createReportContent(c, r, rPrev, files, c.Comment.Message, c.Comment.HideFooterLink, coverageViewer(c.Comment.HideCoverageLink))
 				if err != nil {
 					return err
 				}
@@ -442,7 +454,7 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Summary.Message, c.Summary.HideFooterLink, coverageViewer(c, r, c.Summary.HideCoverageLink))
+				content, err := createReportContent(c, r, rPrev, files, c.Summary.Message, c.Summary.HideFooterLink, coverageViewer(c.Summary.HideCoverageLink))
 				if err != nil {
 					return err
 				}
@@ -471,7 +483,7 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Body.Message, c.Body.HideFooterLink, coverageViewer(c, r, c.Body.HideCoverageLink))
+				content, err := createReportContent(c, r, rPrev, files, c.Body.Message, c.Body.HideFooterLink, coverageViewer(c.Body.HideCoverageLink))
 				if err != nil {
 					return err
 				}
@@ -647,14 +659,14 @@ func init() {
 	rootCmd.Flags().BoolVarP(&createTable, "create-bq-table", "", false, "create table of BigQuery dataset")
 }
 
-// coverageViewer returns the viewer the coverage cells of one output link to. The pages it
-// points at read the report out of a GitHub Actions artifact, so a configuration storing
-// the report anywhere else, or none at all, gets no links rather than dead ones.
-func coverageViewer(c *config.Config, r *report.Report, hide bool) *report.Viewer {
-	if hide {
-		return nil
-	}
-	if err := c.ReportConfigTargetReady(); err != nil {
+// storedArtifactViewer returns the viewer for the artifact this run stores its report in,
+// and nil when it stores none. The pages the coverage cells link to read the report out of
+// a GitHub Actions artifact, so the links have to be gated on the same readiness that
+// decides whether the report is stored at all. Gating on the configured datastores alone
+// would keep linking on a run whose report.if: holds the storing back, at an artifact
+// nothing ever writes.
+func storedArtifactViewer(c *config.Config, r *report.Report) *report.Viewer {
+	if err := c.ReportConfigReady(); err != nil {
 		return nil
 	}
 	name, ok := datastore.ArtifactName(c.Report.Datastores, r)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k1LoW/octocov/config"
+	"github.com/k1LoW/octocov/coverage"
+	"github.com/k1LoW/octocov/report"
+)
+
+func TestStoredArtifactViewer(t *testing.T) {
+	tests := []struct {
+		name       string
+		repository string
+		reportCfg  *config.Report
+		want       string
+	}{
+		{"an artifact datastore is linked", "k1LoW/octocov", &config.Report{Datastores: []string{"artifact://k1LoW/octocov"}}, "https://octocov.dev/k1LoW/octocov/pull/722"},
+		{"a report: that is not set links nowhere", "k1LoW/octocov", nil, ""},
+		{"a report stored anywhere but an artifact links nowhere", "k1LoW/octocov", &config.Report{Datastores: []string{"s3://bucket/prefix"}}, ""},
+		{"a report stored only in a file links nowhere", "k1LoW/octocov", &config.Report{Path: "report.json"}, ""},
+		// The condition is what decides whether this run stores the report at all, so a
+		// report.if: that does not hold has to leave the artifact unlinked. Here it cannot
+		// be evaluated, which is one of the ways it does not hold.
+		{"a report.if: that does not hold links nowhere", "", &config.Report{If: "is_default_branch", Datastores: []string{"artifact://k1LoW/octocov"}}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_REPOSITORY", "k1LoW/octocov")
+			t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+			c := config.New()
+			c.Repository = tt.repository
+			c.Report = tt.reportCfg
+			r := &report.Report{
+				Repository:  "k1LoW/octocov",
+				Ref:         "refs/pull/722/merge",
+				BaseRef:     "refs/heads/main",
+				PullRequest: 722,
+				Commit:      "0123456789abcdef",
+				Coverage:    &coverage.Coverage{Total: 100, Covered: 50},
+			}
+
+			v := storedArtifactViewer(c, r)
+			if (v == nil) != (tt.want == "") {
+				t.Fatalf("got viewer %v\nwant one only when there is a link", v)
+			}
+			// The viewer is observable only through what it renders, which is the thing the
+			// gating is actually about.
+			table := r.Table(v)
+			switch {
+			case tt.want == "":
+				if strings.Contains(table, "octocov.dev") {
+					t.Errorf("got\n%v\nwant no link", table)
+				}
+			default:
+				if !strings.Contains(table, tt.want) {
+					t.Errorf("got\n%v\nwant it to contain\n%v", table, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -48,15 +48,14 @@ func TestStoredArtifactViewer(t *testing.T) {
 			// The viewer is observable only through what it renders, which is the thing the
 			// gating is actually about.
 			table := r.Table(v)
-			switch {
-			case tt.want == "":
+			if tt.want == "" {
 				if strings.Contains(table, "octocov.dev") {
 					t.Errorf("got\n%v\nwant no link", table)
 				}
-			default:
-				if !strings.Contains(table, tt.want) {
-					t.Errorf("got\n%v\nwant it to contain\n%v", table, tt.want)
-				}
+				return
+			}
+			if !strings.Contains(table, tt.want) {
+				t.Errorf("got\n%v\nwant it to contain\n%v", table, tt.want)
 			}
 		})
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -131,23 +131,26 @@ type Push struct {
 }
 
 type Comment struct {
-	HideFooterLink bool   `yaml:"hideFooterLink"`
-	DeletePrevious bool   `yaml:"deletePrevious"`
-	UpdatePrevious bool   `yaml:"updatePrevious"`
-	Message        string `yaml:"message,omitempty"`
-	If             string `yaml:"if,omitempty"`
+	HideFooterLink   bool   `yaml:"hideFooterLink"`
+	HideCoverageLink bool   `yaml:"hideCoverageLink"`
+	DeletePrevious   bool   `yaml:"deletePrevious"`
+	UpdatePrevious   bool   `yaml:"updatePrevious"`
+	Message          string `yaml:"message,omitempty"`
+	If               string `yaml:"if,omitempty"`
 }
 
 type Summary struct {
-	HideFooterLink bool   `yaml:"hideFooterLink"`
-	Message        string `yaml:"message,omitempty"`
-	If             string `yaml:"if,omitempty"`
+	HideFooterLink   bool   `yaml:"hideFooterLink"`
+	HideCoverageLink bool   `yaml:"hideCoverageLink"`
+	Message          string `yaml:"message,omitempty"`
+	If               string `yaml:"if,omitempty"`
 }
 
 type Body struct {
-	HideFooterLink bool   `yaml:"hideFooterLink"`
-	Message        string `yaml:"message,omitempty"`
-	If             string `yaml:"if,omitempty"`
+	HideFooterLink   bool   `yaml:"hideFooterLink"`
+	HideCoverageLink bool   `yaml:"hideCoverageLink"`
+	Message          string `yaml:"message,omitempty"`
+	If               string `yaml:"if,omitempty"`
 }
 
 type Diff struct {

--- a/datastore/artifact/artifact.go
+++ b/datastore/artifact/artifact.go
@@ -46,7 +46,7 @@ func New(gh *gh.Gh, repo, name string, r *report.Report) (*Artifact, error) {
 }
 
 func (a *Artifact) StoreReport(ctx context.Context, r *report.Report) error {
-	name, err := a.storeName(r)
+	name, err := a.StoreName(r)
 	if err != nil {
 		return err
 	}
@@ -97,10 +97,10 @@ func (a *Artifact) FS() (fs.FS, error) {
 	return &fsys, nil
 }
 
-// storeName returns the artifact name the report is stored under. The report of the
+// StoreName returns the artifact name the report is stored under. The report of the
 // default branch keeps the configured name, which is the one FS() looks up, so a
 // comparison and the central mode keep reading the branch they are meant to describe.
-func (a *Artifact) storeName(r *report.Report) (string, error) {
+func (a *Artifact) StoreName(r *report.Report) (string, error) {
 	name := a.name
 	switch {
 	case a.repository == r.Repository:

--- a/datastore/artifact/artifact_test.go
+++ b/datastore/artifact/artifact_test.go
@@ -34,7 +34,7 @@ func TestStoreName(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, err := a.storeName(&report.Report{
+			got, err := a.StoreName(&report.Report{
 				Repository:  tt.repository,
 				Ref:         tt.ref,
 				BaseRef:     tt.baseRef,
@@ -63,7 +63,7 @@ func TestStoreNameHasNoInvalidCharacter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := a.storeName(&report.Report{
+	got, err := a.StoreName(&report.Report{
 		Repository: "owner/repo",
 		Ref:        `refs/heads/feat/"a:b<c>d|e*f?g\h`,
 		BaseRef:    "refs/heads/main",

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -246,12 +246,15 @@ func parse(u, root string) (Type, []string, error) {
 	}
 }
 
-// ArtifactName returns the name of the artifact the report is stored under by the first
-// artifact:// datastore of us, and reports whether there is one. The pages that browse a
-// stored report read it out of the artifacts, so a configuration that stores anywhere else
-// leaves them no name to look one up by.
-func ArtifactName(us []string, r *report.Report) (string, bool) {
-	for _, u := range us {
+// ArtifactName returns the name that the first artifact:// entry of datastores stores the
+// report under, and reports whether there is such an entry. The pages that browse a stored
+// report read it out of the artifacts, so a configuration that stores anywhere else leaves
+// them no name to look one up by.
+func ArtifactName(datastores []string, r *report.Report) (string, bool) {
+	if r == nil {
+		return "", false
+	}
+	for _, u := range datastores {
 		d, args, err := parse(u, "")
 		if err != nil || d != Artifact {
 			continue

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -246,6 +246,29 @@ func parse(u, root string) (Type, []string, error) {
 	}
 }
 
+// ArtifactName returns the name of the artifact the report is stored under by the first
+// artifact:// datastore of us, and reports whether there is one. The pages that browse a
+// stored report read it out of the artifacts, so a configuration that stores anywhere else
+// leaves them no name to look one up by.
+func ArtifactName(us []string, r *report.Report) (string, bool) {
+	for _, u := range us {
+		d, args, err := parse(u, "")
+		if err != nil || d != Artifact {
+			continue
+		}
+		a, err := artifact.New(nil, args[0], args[1], r)
+		if err != nil {
+			continue
+		}
+		n, err := a.StoreName(r)
+		if err != nil {
+			continue
+		}
+		return n, true
+	}
+	return "", false
+}
+
 func NeedToShrink(u string) bool {
 	return strings.HasPrefix(u, "bq://")
 }

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/k1LoW/octocov/report"
 )
 
 func TestParse(t *testing.T) {
@@ -76,4 +77,39 @@ func testdataDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return dir
+}
+
+func TestArtifactName(t *testing.T) {
+	tests := []struct {
+		name       string
+		datastores []string
+		want       string
+		wantOK     bool
+	}{
+		{"the default artifact name of a pull request", []string{"artifact://k1LoW/octocov"}, "octocov-report@refs_pull_722", true},
+		{"a configured artifact name", []string{"artifact://k1LoW/octocov/mine"}, "mine@refs_pull_722", true},
+		{"the artifacts scheme spelled in the plural", []string{"artifacts://k1LoW/octocov"}, "octocov-report@refs_pull_722", true},
+		{"the first artifact datastore wins", []string{"s3://bucket/prefix", "artifact://k1LoW/octocov", "artifact://k1LoW/octocov/other"}, "octocov-report@refs_pull_722", true},
+		{"no artifact datastore leaves no name", []string{"s3://bucket/prefix", "bq://project/dataset/table"}, "", false},
+		{"no datastore at all leaves no name", nil, "", false},
+		{"an unparsable datastore is passed over", []string{"artifact://k1LoW"}, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_REPOSITORY", "k1LoW/octocov")
+			r := &report.Report{
+				Repository:  "k1LoW/octocov",
+				Ref:         "refs/pull/722/merge",
+				BaseRef:     "refs/heads/main",
+				PullRequest: 722,
+			}
+			got, ok := ArtifactName(tt.datastores, r)
+			if ok != tt.wantOK {
+				t.Fatalf("got ok %v\nwant %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("got %v\nwant %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -94,6 +94,13 @@ func TestArtifactName(t *testing.T) {
 		{"no datastore at all leaves no name", nil, "", false},
 		{"an unparsable datastore is passed over", []string{"artifact://k1LoW"}, "", false},
 	}
+	t.Run("a report that is not there leaves no name", func(t *testing.T) {
+		t.Setenv("GITHUB_REPOSITORY", "k1LoW/octocov")
+		got, ok := ArtifactName([]string{"artifact://k1LoW/octocov"}, nil)
+		if ok || got != "" {
+			t.Errorf("got %q %v\nwant an empty name", got, ok)
+		}
+	})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GITHUB_REPOSITORY", "k1LoW/octocov")

--- a/report/diff_report.go
+++ b/report/diff_report.go
@@ -56,14 +56,15 @@ func (d *DiffReport) Out(w io.Writer) {
 	r := tablewriter.Colors{tablewriter.Bold, tablewriter.FgRedColor}
 	b := tablewriter.Colors{tablewriter.Bold}
 
-	d.renderTable(table, g, r, b, true, false)
+	// No viewer, since this is the terminal output, where a markdown link is noise.
+	d.renderTable(table, g, r, b, true, false, nil)
 
 	table.Render()
 }
 
 var leftSepRe = regexp.MustCompile(`(?m)^\|`)
 
-func (d *DiffReport) Table() string {
+func (d *DiffReport) Table(v *Viewer) string {
 	var out []string
 
 	// Markdown table
@@ -74,7 +75,7 @@ func (d *DiffReport) Table() string {
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetCenterSeparator("|")
 	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT})
-	d.renderTable(table, tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{}, false, true)
+	d.renderTable(table, tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{}, false, true, v)
 	table.Render()
 	out = append(out, strings.Replace(strings.Replace(buf.String(), "---|", "--:|", 4), "--:|", "---|", 1))
 
@@ -85,7 +86,7 @@ func (d *DiffReport) Table() string {
 	table2.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table2.SetCenterSeparator("|")
 	table2.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT})
-	d.renderTable(table2, tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{}, true, false)
+	d.renderTable(table2, tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{}, true, false, nil)
 	table2.Render()
 	t2 := leftSepRe.ReplaceAllString(buf2.String(), "  |")
 	if d.Coverage != nil {
@@ -128,7 +129,7 @@ func (d *DiffReport) Table() string {
 	return strings.Join(out, "\n")
 }
 
-func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd string) string {
+func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd string, v *Viewer) string {
 	if d.Coverage == nil {
 		return ""
 	}
@@ -138,7 +139,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd strin
 	var t, c, prevT, prevC int
 	var patchT, patchC int
 	var rows [][]string
-	createRow := func(name string, fc *coverage.DiffFileCoverage, status string, changedLines []int) []string {
+	createRow := func(name, path string, fc *coverage.DiffFileCoverage, status string, changedLines []int) []string {
 		diff := fmt.Sprintf("%.1f%%", floor1(fc.Diff))
 		if fc.Diff > 0 {
 			diff = fmt.Sprintf("+%s", diff)
@@ -155,7 +156,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd strin
 		pfc := fc.FileCoverageA.PatchCoverage(changedLines)
 		patchC += pfc.Covered
 		patchT += pfc.Total
-		return []string{name, fmt.Sprintf("%.1f%%", floor1(fc.A)), diff, patchCell(pfc), status}
+		return []string{name, linkCell(fmt.Sprintf("%.1f%%", floor1(fc.A)), v.fileURL(d.ReportA, path)), diff, patchCell(pfc), status}
 	}
 
 	prFiles := map[string]*gh.PullRequestFile{}
@@ -170,7 +171,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd strin
 	for _, fc := range d.Coverage.Files {
 		if prf, ok := prFiles[fc.File]; ok {
 			name := fmt.Sprintf("[%s](%s)", prf.Filename, prf.BlobURL)
-			rows = append(rows, createRow(name, fc, prf.Status, prf.ChangedLines))
+			rows = append(rows, createRow(name, prf.Filename, fc, prf.Status, prf.ChangedLines))
 			continue
 		}
 		if fc.Diff == 0 {
@@ -195,7 +196,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd strin
 		if repoURL != "/" && commit != "" && !filepath.IsAbs(filePath) {
 			name = fmt.Sprintf("[%s](%s/blob/%s/%s)", filePath, repoURL, commit, filePath)
 		}
-		rows = append(rows, createRow(name, fc, "affected", nil))
+		rows = append(rows, createRow(name, filePath, fc, "affected", nil))
 	}
 	if len(rows) == 0 {
 		return ""
@@ -249,7 +250,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd strin
 	return strings.Replace(strings.Replace(buf.String(), "---|", "--:|", len(h)), "--:|", "---|", 1)
 }
 
-func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.Colors, detail bool, withLink bool) {
+func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.Colors, detail bool, withLink bool, v *Viewer) {
 	if withLink {
 		table.SetHeader([]string{"", makeHeadTitleWithLink(d.RefB, d.CommitB, d.ReportB.covPaths), makeHeadTitleWithLink(d.RefA, d.CommitA, d.ReportA.covPaths), "+/-"})
 	} else {
@@ -271,7 +272,10 @@ func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.C
 			if !detail {
 				t = "**Coverage**"
 			}
-			table.Rich([]string{t, fmt.Sprintf("%.1f%%", floor1(d.Coverage.B)), fmt.Sprintf("%.1f%%", floor1(d.Coverage.A)), ds}, []tablewriter.Colors{b, tablewriter.Colors{}, tablewriter.Colors{}, cc})
+			// The current side only, since the compared one names a commit whose report
+			// lives in an artifact of its own.
+			a := linkCell(fmt.Sprintf("%.1f%%", floor1(d.Coverage.A)), v.reportURL(d.ReportA))
+			table.Rich([]string{t, fmt.Sprintf("%.1f%%", floor1(d.Coverage.B)), a, ds}, []tablewriter.Colors{b, tablewriter.Colors{}, tablewriter.Colors{}, cc})
 		}
 		if detail && d.Coverage.CoverageA != nil && d.Coverage.CoverageB != nil {
 			{

--- a/report/diff_report.go
+++ b/report/diff_report.go
@@ -190,7 +190,9 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd strin
 
 		filePath := name
 		if relWd != "" && !strings.HasPrefix(filePath, relWd+"/") && !filepath.IsAbs(filePath) {
-			filePath = filepath.Clean(filepath.Join(relWd, filePath))
+			// ToSlash, since what comes out is a path inside a URL rather than one on the
+			// running OS, and filepath.Join separates with a backslash on Windows.
+			filePath = filepath.ToSlash(filepath.Clean(filepath.Join(relWd, filePath)))
 		}
 
 		if repoURL != "/" && commit != "" && !filepath.IsAbs(filePath) {

--- a/report/diff_report.go
+++ b/report/diff_report.go
@@ -272,10 +272,10 @@ func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.C
 			if !detail {
 				t = "**Coverage**"
 			}
-			// The current side only, since the compared one names a commit whose report
-			// lives in an artifact of its own.
-			a := linkCell(fmt.Sprintf("%.1f%%", floor1(d.Coverage.A)), v.reportURL(d.ReportA))
-			table.Rich([]string{t, fmt.Sprintf("%.1f%%", floor1(d.Coverage.B)), a, ds}, []tablewriter.Colors{b, tablewriter.Colors{}, tablewriter.Colors{}, cc})
+			// Both sides, since each report names the ref its own page is routed by.
+			prev := linkCell(fmt.Sprintf("%.1f%%", floor1(d.Coverage.B)), v.reportURL(d.ReportB))
+			cur := linkCell(fmt.Sprintf("%.1f%%", floor1(d.Coverage.A)), v.reportURL(d.ReportA))
+			table.Rich([]string{t, prev, cur, ds}, []tablewriter.Colors{b, tablewriter.Colors{}, tablewriter.Colors{}, cc})
 		}
 		if detail && d.Coverage.CoverageA != nil && d.Coverage.CoverageB != nil {
 			{

--- a/report/diff_report_test.go
+++ b/report/diff_report_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/k1LoW/octocov/gh"
@@ -45,7 +46,7 @@ func TestDiffTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := a.Compare(b).Table()
+	got := a.Compare(b).Table(nil)
 	f := "diff_table"
 	if os.Getenv("UPDATE_GOLDEN") != "" {
 		golden.Update(t, testdataDir(t), f, got)
@@ -75,7 +76,7 @@ func TestDiffFileCoveragesTable(t *testing.T) {
 		{Filename: "zcase/removed.go", BlobURL: "https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed.go", Status: "removed"},
 		{Filename: "zcase/removed_test.go", BlobURL: "https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed_test.go", Status: "removed"},
 		{Filename: "zcase/rename_new.go", BlobURL: "https://github.com/k1LoW/octocov/blob/afterhash/zcase/rename_new.go", Status: "renamed"},
-	}, "")
+	}, "", nil)
 	f := "diff_file_coverages_table"
 	if os.Getenv("UPDATE_GOLDEN") != "" {
 		golden.Update(t, testdataDir(t), f, got)
@@ -105,7 +106,7 @@ func TestDiffFileCoveragesTableWithPatch(t *testing.T) {
 		{Filename: "zcase/removed.go", BlobURL: "https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed.go", Status: "removed"},
 		{Filename: "zcase/removed_test.go", BlobURL: "https://github.com/k1LoW/octocov/blob/beforehash/zcase/removed_test.go", Status: "removed"},
 		{Filename: "zcase/rename_new.go", BlobURL: "https://github.com/k1LoW/octocov/blob/afterhash/zcase/rename_new.go", Status: "renamed", ChangedLines: []int{5, 6, 9}},
-	}, "")
+	}, "", nil)
 	f := "diff_file_coverages_table_with_patch"
 	if os.Getenv("UPDATE_GOLDEN") != "" {
 		golden.Update(t, testdataDir(t), f, got)
@@ -113,5 +114,32 @@ func TestDiffFileCoveragesTableWithPatch(t *testing.T) {
 	}
 	if diff := golden.Diff(t, testdataDir(t), f, got); diff != "" {
 		t.Error(diff)
+	}
+}
+
+func TestDiffTableLinksCurrentCoverageToTheViewer(t *testing.T) {
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	a := &Report{}
+	if err := a.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json")); err != nil {
+		t.Fatal(err)
+	}
+	b := &Report{}
+	if err := b.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json")); err != nil {
+		t.Fatal(err)
+	}
+	a.Repository = "k1LoW/tbls"
+	a.PullRequest = 722
+
+	got := a.Compare(b).Table(NewViewer("octocov-report@refs_pull_722"))
+	if want := "](https://octocov.dev/k1LoW/tbls/pull/722)"; !strings.Contains(got, want) {
+		t.Errorf("got\n%v\nwant it to contain\n%v", got, want)
+	}
+	// One cell only, since the compared side names a commit whose report lives in an
+	// artifact of its own, and the diff code block is not markdown.
+	if n := strings.Count(got, "octocov.dev"); n != 1 {
+		t.Errorf("got %d links\nwant 1\n%v", n, got)
+	}
+	if strings.Contains(a.Compare(b).Table(nil), "octocov.dev") {
+		t.Error("a nil viewer must not link to the viewer")
 	}
 }

--- a/report/diff_report_test.go
+++ b/report/diff_report_test.go
@@ -117,7 +117,7 @@ func TestDiffFileCoveragesTableWithPatch(t *testing.T) {
 	}
 }
 
-func TestDiffTableLinksCurrentCoverageToTheViewer(t *testing.T) {
+func TestDiffTableLinksBothCoveragesToTheViewer(t *testing.T) {
 	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
 	a := &Report{}
 	if err := a.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json")); err != nil {
@@ -128,16 +128,27 @@ func TestDiffTableLinksCurrentCoverageToTheViewer(t *testing.T) {
 		t.Fatal(err)
 	}
 	a.Repository = "k1LoW/tbls"
+	a.Ref = "refs/pull/722/merge"
+	a.BaseRef = "refs/heads/main"
 	a.PullRequest = 722
+	// The compared side is the report of the default branch, which the viewer serves as the
+	// repository itself.
+	b.Repository = "k1LoW/tbls"
+	b.Ref = "refs/heads/main"
+	b.BaseRef = "refs/heads/main"
 
 	got := a.Compare(b).Table(NewViewer("octocov-report@refs_pull_722"))
-	if want := "](https://octocov.dev/k1LoW/tbls/pull/722)"; !strings.Contains(got, want) {
-		t.Errorf("got\n%v\nwant it to contain\n%v", got, want)
+	for _, want := range []string{
+		"](https://octocov.dev/k1LoW/tbls/pull/722)",
+		"](https://octocov.dev/k1LoW/tbls)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("got\n%v\nwant it to contain\n%v", got, want)
+		}
 	}
-	// One cell only, since the compared side names a commit whose report lives in an
-	// artifact of its own, and the diff code block is not markdown.
-	if n := strings.Count(got, "octocov.dev"); n != 1 {
-		t.Errorf("got %d links\nwant 1\n%v", n, got)
+	// The two coverage cells only, since the diff code block is not markdown.
+	if n := strings.Count(got, "octocov.dev"); n != 2 {
+		t.Errorf("got %d links\nwant 2\n%v", n, got)
 	}
 	if strings.Contains(a.Compare(b).Table(nil), "octocov.dev") {
 		t.Error("a nil viewer must not link to the viewer")

--- a/report/diff_report_test.go
+++ b/report/diff_report_test.go
@@ -154,3 +154,34 @@ func TestDiffTableLinksBothCoveragesToTheViewer(t *testing.T) {
 		t.Error("a nil viewer must not link to the viewer")
 	}
 }
+
+func TestDiffFileCoveragesTablePathsAreSlashSeparated(t *testing.T) {
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	t.Setenv("GITHUB_REPOSITORY", "k1LoW/octocov")
+	a := &Report{}
+	if err := a.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "octocov", "report2.json")); err != nil {
+		t.Fatal(err)
+	}
+	b := &Report{}
+	if err := b.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "octocov", "report1.json")); err != nil {
+		t.Fatal(err)
+	}
+	a.Repository = "k1LoW/octocov"
+	a.Commit = "0123456789abcdef"
+
+	// relWd is joined onto the files that the pull request did not report, with
+	// filepath.Join, which separates with a backslash on Windows. Both the source link and
+	// the viewer link built from the result are URLs.
+	got := a.Compare(b).FileCoveragesTable([]*gh.PullRequestFile{ //nostyle:funcfmt
+		{Filename: "no-such-file.go", BlobURL: "https://github.com/k1LoW/octocov/blob/0123456789abcdef/no-such-file.go"},
+	}, "sub", NewViewer("octocov-report"))
+	if got == "" {
+		t.Fatal("got an empty table, so nothing was checked")
+	}
+	if strings.Contains(got, `\`) {
+		t.Errorf("got\n%v\nwant no backslash", got)
+	}
+	if !strings.Contains(got, "sub/") {
+		t.Errorf("got\n%v\nwant it to carry the joined prefix", got)
+	}
+}

--- a/report/report.go
+++ b/report/report.go
@@ -202,14 +202,14 @@ func (r *Report) Bytes() []byte {
 	return b
 }
 
-func (r *Report) Table() string {
+func (r *Report) Table(v *Viewer) string {
 	var (
 		h []string
 		m []string
 	)
 	if r.IsMeasuredCoverage() {
 		h = append(h, "Coverage")
-		m = append(m, fmt.Sprintf("%.1f%%", floor1(r.CoveragePercent())))
+		m = append(m, linkCell(fmt.Sprintf("%.1f%%", floor1(r.CoveragePercent())), v.reportURL(r)))
 	}
 	if r.IsMeasuredCodeToTestRatio() {
 		h = append(h, "Code to Test Ratio")
@@ -272,7 +272,7 @@ func (r *Report) Out(w io.Writer) error {
 	return nil
 }
 
-func (r *Report) FileCoveragesTable(files []*gh.PullRequestFile) string {
+func (r *Report) FileCoveragesTable(files []*gh.PullRequestFile, v *Viewer) string {
 	if r.Coverage == nil {
 		return ""
 	}
@@ -297,7 +297,7 @@ func (r *Report) FileCoveragesTable(files []*gh.PullRequestFile) string {
 		pfc := fc.PatchCoverage(f.ChangedLines)
 		patchC += pfc.Covered
 		patchT += pfc.Total
-		rows = append(rows, []string{fmt.Sprintf("[%s](%s)", f.Filename, f.BlobURL), fmt.Sprintf("%.1f%%", floor1(cover)), patchCell(pfc)})
+		rows = append(rows, []string{fmt.Sprintf("[%s](%s)", f.Filename, f.BlobURL), linkCell(fmt.Sprintf("%.1f%%", floor1(cover)), v.fileURL(r, f.Filename)), patchCell(pfc)})
 	}
 	if !exist {
 		return ""

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -354,7 +354,7 @@ func TestTable(t *testing.T) {
 		if err := r.Load(tt.path); err != nil {
 			t.Fatal(err)
 		}
-		if got := r.Table(); got != tt.want {
+		if got := r.Table(nil); got != tt.want {
 			t.Errorf("got\n%v\nwant\n%v", got, tt.want)
 		}
 		orig := r.String()
@@ -429,7 +429,7 @@ func TestFileCoveragesTable(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, tt := range tests {
-		if got := r.FileCoveragesTable(tt.files); got != tt.want {
+		if got := r.FileCoveragesTable(tt.files, nil); got != tt.want {
 			t.Errorf("got\n%v\nwant\n%v", got, tt.want)
 		}
 	}
@@ -736,5 +736,49 @@ func TestBytesOmitsUnsetRefFields(t *testing.T) {
 		if strings.Contains(got, k) {
 			t.Errorf("got %v\nwant no %s", got, k)
 		}
+	}
+}
+
+func TestTableLinksCoverageToTheViewer(t *testing.T) {
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	r := &Report{}
+	if err := r.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json")); err != nil {
+		t.Fatal(err)
+	}
+	r.Repository = "k1LoW/tbls"
+	r.PullRequest = 722
+
+	if got, want := r.Table(NewViewer("octocov-report@refs_pull_722")), "[68.4%](https://octocov.dev/k1LoW/tbls/pull/722)"; !strings.Contains(got, want) {
+		t.Errorf("got\n%v\nwant it to contain\n%v", got, want)
+	}
+	// The same table without a viewer keeps the cell as it has always been rendered.
+	if got, want := r.Table(nil), "| 68.4%    |"; !strings.Contains(got, want) {
+		t.Errorf("got\n%v\nwant it to contain\n%v", got, want)
+	}
+}
+
+func TestFileCoveragesTableLinksCoverageToTheViewer(t *testing.T) {
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	r := &Report{}
+	if err := r.Load(filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json")); err != nil {
+		t.Fatal(err)
+	}
+	r.Repository = "k1LoW/tbls"
+	r.Commit = "0123456789abcdef"
+	files := []*gh.PullRequestFile{
+		{Filename: r.Coverage.Files[0].File, BlobURL: "https://github.com/k1LoW/tbls/blob/0123456789abcdef/f"},
+	}
+
+	got := r.FileCoveragesTable(files, NewViewer("octocov-report@refs_pull_722"))
+	want := "?artifact_name=octocov-report%40refs_pull_722&commit=0123456789abcdef)"
+	if !strings.Contains(got, want) {
+		t.Errorf("got\n%v\nwant it to contain\n%v", got, want)
+	}
+	// The file name keeps pointing at the source on GitHub.
+	if !strings.Contains(got, "https://github.com/k1LoW/tbls/blob/0123456789abcdef/f") {
+		t.Errorf("got\n%v\nwant it to keep the blob link", got)
+	}
+	if strings.Contains(r.FileCoveragesTable(files, nil), "octocov.dev") {
+		t.Error("a nil viewer must not link to the viewer")
 	}
 }

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -770,7 +770,7 @@ func TestFileCoveragesTableLinksCoverageToTheViewer(t *testing.T) {
 	}
 
 	got := r.FileCoveragesTable(files, NewViewer("octocov-report@refs_pull_722"))
-	want := "?artifact_name=octocov-report%40refs_pull_722&commit=0123456789abcdef)"
+	want := "?artifact_name=octocov-report%40refs_pull_722)"
 	if !strings.Contains(got, want) {
 		t.Errorf("got\n%v\nwant it to contain\n%v", got, want)
 	}

--- a/report/viewer.go
+++ b/report/viewer.go
@@ -78,7 +78,9 @@ func (v *Viewer) fileURL(r *Report, path string) string {
 // run is one they can serve at all. They read the artifacts through the github.com API, so
 // a GitHub Enterprise Server run has nothing there for them to show.
 func viewerRepo(r *Report) (*gh.Repository, bool) {
-	if s := os.Getenv("GITHUB_SERVER_URL"); s != "" && s != "https://github.com" {
+	// Trailing slashes trimmed, since the same server can be named with or without one and
+	// only a different host means the artifacts are somewhere the pages cannot reach.
+	if s := strings.TrimRight(os.Getenv("GITHUB_SERVER_URL"), "/"); s != "" && s != gh.DefaultGithubServerURL {
 		return nil, false
 	}
 	repo, err := gh.Parse(r.Repository)

--- a/report/viewer.go
+++ b/report/viewer.go
@@ -31,17 +31,30 @@ func NewViewer(artifactName string) *Viewer {
 	return &Viewer{artifactName: artifactName}
 }
 
-// reportURL returns the page of the report as a whole. Only a pull request has one, since
-// that page is reached by the pull request number rather than by the artifact name.
+// reportURL returns the page of the report as a whole. That page is routed by the ref
+// rather than by the artifact name, and the ref key is what says which one, so the report
+// of the default branch is the repository itself and every other ref has a page beside it.
 func (v *Viewer) reportURL(r *Report) string {
-	if v == nil || r == nil || r.PullRequest <= 0 {
+	if v == nil || r == nil {
 		return ""
 	}
 	repo, ok := viewerRepo(r)
 	if !ok {
 		return ""
 	}
-	return fmt.Sprintf("%s/%s/%s/pull/%d", viewerBaseURL, repo.Owner, repo.Repo, r.PullRequest)
+	base := fmt.Sprintf("%s/%s/%s", viewerBaseURL, repo.Owner, repo.Repo)
+	key := r.RefKey()
+	switch {
+	case key == "":
+		return base
+	case strings.HasPrefix(key, "refs/pull/"):
+		return fmt.Sprintf("%s/pull/%s", base, strings.TrimPrefix(key, "refs/pull/"))
+	case strings.HasPrefix(key, "refs/heads/"):
+		return fmt.Sprintf("%s/tree/%s", base, escapePath(strings.TrimPrefix(key, "refs/heads/")))
+	default:
+		// A tag, which has no page of its own.
+		return ""
+	}
 }
 
 // fileURL returns the page of one file's coverage. The pull request path carries no

--- a/report/viewer.go
+++ b/report/viewer.go
@@ -58,9 +58,11 @@ func (v *Viewer) reportURL(r *Report) string {
 }
 
 // fileURL returns the page of one file's coverage. The pull request path carries no
-// per-file page, so the report is named by its artifact in the query instead.
+// per-file page, so the report is named by its artifact in the query instead. The artifact
+// name is the whole of what the page needs to find the report, since the commit only ever
+// reaches a cache keyed by an artifact id this side has no way to know.
 func (v *Viewer) fileURL(r *Report, path string) string {
-	if v == nil || r == nil || r.Commit == "" || path == "" {
+	if v == nil || r == nil || path == "" {
 		return ""
 	}
 	repo, ok := viewerRepo(r)
@@ -69,7 +71,6 @@ func (v *Viewer) fileURL(r *Report, path string) string {
 	}
 	q := url.Values{}
 	q.Set("artifact_name", v.artifactName)
-	q.Set("commit", r.Commit)
 	return fmt.Sprintf("%s/%s/%s/file/%s?%s", viewerBaseURL, repo.Owner, repo.Repo, escapePath(path), q.Encode())
 }
 

--- a/report/viewer.go
+++ b/report/viewer.go
@@ -1,0 +1,94 @@
+package report
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/k1LoW/octocov/gh"
+)
+
+// viewerBaseURL is where a report stored in a GitHub Actions artifact can be browsed.
+const viewerBaseURL = "https://octocov.dev"
+
+// Viewer turns the coverage cells of the rendered tables into links to the pages that
+// browse the report behind them. A report is addressed there by the artifact it was stored
+// under, so a Viewer is built from that name.
+//
+// A nil Viewer renders every cell as plain text, which lets a caller with no artifact
+// datastore, or one that turned the links off, pass nil rather than branch at each cell.
+type Viewer struct {
+	artifactName string
+}
+
+// NewViewer returns the viewer of the report stored under artifactName, or nil when the
+// name is empty.
+func NewViewer(artifactName string) *Viewer {
+	if artifactName == "" {
+		return nil
+	}
+	return &Viewer{artifactName: artifactName}
+}
+
+// reportURL returns the page of the report as a whole. Only a pull request has one, since
+// that page is reached by the pull request number rather than by the artifact name.
+func (v *Viewer) reportURL(r *Report) string {
+	if v == nil || r == nil || r.PullRequest <= 0 {
+		return ""
+	}
+	repo, ok := viewerRepo(r)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/%s/pull/%d", viewerBaseURL, repo.Owner, repo.Repo, r.PullRequest)
+}
+
+// fileURL returns the page of one file's coverage. The pull request path carries no
+// per-file page, so the report is named by its artifact in the query instead.
+func (v *Viewer) fileURL(r *Report, path string) string {
+	if v == nil || r == nil || r.Commit == "" || path == "" {
+		return ""
+	}
+	repo, ok := viewerRepo(r)
+	if !ok {
+		return ""
+	}
+	q := url.Values{}
+	q.Set("artifact_name", v.artifactName)
+	q.Set("commit", r.Commit)
+	return fmt.Sprintf("%s/%s/%s/file/%s?%s", viewerBaseURL, repo.Owner, repo.Repo, escapePath(path), q.Encode())
+}
+
+// viewerRepo returns the repository the pages are served under, and reports whether the
+// run is one they can serve at all. They read the artifacts through the github.com API, so
+// a GitHub Enterprise Server run has nothing there for them to show.
+func viewerRepo(r *Report) (*gh.Repository, bool) {
+	if s := os.Getenv("GITHUB_SERVER_URL"); s != "" && s != "https://github.com" {
+		return nil, false
+	}
+	repo, err := gh.Parse(r.Repository)
+	if err != nil {
+		return nil, false
+	}
+	return repo, true
+}
+
+// escapePath escapes each segment of a file path on its own, so that the separators stay
+// separators while a space or a hash inside a name does not end the path.
+func escapePath(path string) string {
+	segments := strings.Split(path, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return strings.Join(segments, "/")
+}
+
+// linkCell wraps a rendered cell in a markdown link, and leaves it as it is when there is
+// no page to point at.
+func linkCell(cell, u string) string {
+	if u == "" {
+		return cell
+	}
+	return fmt.Sprintf("[%s](%s)", cell, u)
+}

--- a/report/viewer_test.go
+++ b/report/viewer_test.go
@@ -23,6 +23,8 @@ func TestViewerReportURL(t *testing.T) {
 		{"a report stored in no artifact links nowhere", "", "", "k1LoW/octocov", "refs/pull/722/merge", "refs/heads/main", 722, ""},
 		{"a GitHub Enterprise Server run links nowhere", "octocov-report@refs_pull_722", "https://github.example.com", "k1LoW/octocov", "refs/pull/722/merge", "refs/heads/main", 722, ""},
 		{"github.com stated explicitly is served", "octocov-report@refs_pull_722", "https://github.com", "k1LoW/octocov", "refs/pull/722/merge", "refs/heads/main", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
+		// The same server either way, so the slash must not read as another host.
+		{"github.com with a trailing slash is served", "octocov-report@refs_pull_722", "https://github.com/", "k1LoW/octocov", "refs/pull/722/merge", "refs/heads/main", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/report/viewer_test.go
+++ b/report/viewer_test.go
@@ -8,21 +8,27 @@ func TestViewerReportURL(t *testing.T) {
 		artifactName string
 		serverURL    string
 		repository   string
+		ref          string
+		baseRef      string
 		pullRequest  int
 		want         string
 	}{
-		{"a pull request has a page of its own", "octocov-report@refs_pull_722", "", "k1LoW/octocov", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
-		{"a run that is not on a pull request has none", "octocov-report", "", "k1LoW/octocov", 0, ""},
-		{"a report of a sub directory is served under its repository", "octocov-report-sub@refs_pull_722", "", "k1LoW/octocov/sub", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
-		{"a report stored in no artifact links nowhere", "", "", "k1LoW/octocov", 722, ""},
-		{"a GitHub Enterprise Server run links nowhere", "octocov-report@refs_pull_722", "https://github.example.com", "k1LoW/octocov", 722, ""},
-		{"github.com stated explicitly is served", "octocov-report@refs_pull_722", "https://github.com", "k1LoW/octocov", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
+		{"a pull request has a page of its own", "octocov-report@refs_pull_722", "", "k1LoW/octocov", "refs/pull/722/merge", "refs/heads/main", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
+		{"the default branch is the repository itself", "octocov-report", "", "k1LoW/octocov", "refs/heads/main", "refs/heads/main", 0, "https://octocov.dev/k1LoW/octocov"},
+		{"a branch has a tree page", "octocov-report@refs_heads_feat_x", "", "k1LoW/octocov", "refs/heads/feat/x", "refs/heads/main", 0, "https://octocov.dev/k1LoW/octocov/tree/feat/x"},
+		{"a branch name is escaped segment by segment", "octocov-report", "", "k1LoW/octocov", "refs/heads/feat/a b", "refs/heads/main", 0, "https://octocov.dev/k1LoW/octocov/tree/feat/a%20b"},
+		{"a tag has no page of its own", "octocov-report", "", "k1LoW/octocov", "refs/tags/v1.0.0", "refs/heads/main", 0, ""},
+		{"a report predating the base ref is read as the repository", "octocov-report", "", "k1LoW/octocov", "refs/heads/whatever", "", 0, "https://octocov.dev/k1LoW/octocov"},
+		{"a report of a sub directory is served under its repository", "octocov-report-sub@refs_pull_722", "", "k1LoW/octocov/sub", "refs/pull/722/merge", "refs/heads/main", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
+		{"a report stored in no artifact links nowhere", "", "", "k1LoW/octocov", "refs/pull/722/merge", "refs/heads/main", 722, ""},
+		{"a GitHub Enterprise Server run links nowhere", "octocov-report@refs_pull_722", "https://github.example.com", "k1LoW/octocov", "refs/pull/722/merge", "refs/heads/main", 722, ""},
+		{"github.com stated explicitly is served", "octocov-report@refs_pull_722", "https://github.com", "k1LoW/octocov", "refs/pull/722/merge", "refs/heads/main", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GITHUB_SERVER_URL", tt.serverURL)
 			v := NewViewer(tt.artifactName)
-			got := v.reportURL(&Report{Repository: tt.repository, PullRequest: tt.pullRequest, Commit: "0123456789abcdef"})
+			got := v.reportURL(&Report{Repository: tt.repository, Ref: tt.ref, BaseRef: tt.baseRef, PullRequest: tt.pullRequest, Commit: "0123456789abcdef"})
 			if got != tt.want {
 				t.Errorf("got %v\nwant %v", got, tt.want)
 			}

--- a/report/viewer_test.go
+++ b/report/viewer_test.go
@@ -1,0 +1,68 @@
+package report
+
+import "testing"
+
+func TestViewerReportURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		artifactName string
+		serverURL    string
+		repository   string
+		pullRequest  int
+		want         string
+	}{
+		{"a pull request has a page of its own", "octocov-report@refs_pull_722", "", "k1LoW/octocov", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
+		{"a run that is not on a pull request has none", "octocov-report", "", "k1LoW/octocov", 0, ""},
+		{"a report of a sub directory is served under its repository", "octocov-report-sub@refs_pull_722", "", "k1LoW/octocov/sub", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
+		{"a report stored in no artifact links nowhere", "", "", "k1LoW/octocov", 722, ""},
+		{"a GitHub Enterprise Server run links nowhere", "octocov-report@refs_pull_722", "https://github.example.com", "k1LoW/octocov", 722, ""},
+		{"github.com stated explicitly is served", "octocov-report@refs_pull_722", "https://github.com", "k1LoW/octocov", 722, "https://octocov.dev/k1LoW/octocov/pull/722"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_SERVER_URL", tt.serverURL)
+			v := NewViewer(tt.artifactName)
+			got := v.reportURL(&Report{Repository: tt.repository, PullRequest: tt.pullRequest, Commit: "0123456789abcdef"})
+			if got != tt.want {
+				t.Errorf("got %v\nwant %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestViewerFileURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		artifactName string
+		serverURL    string
+		commit       string
+		path         string
+		want         string
+	}{
+		{"a file is named by the artifact holding its report", "octocov-report@refs_pull_722", "", "0123456789abcdef", "report/report.go", "https://octocov.dev/k1LoW/octocov/file/report/report.go?artifact_name=octocov-report%40refs_pull_722&commit=0123456789abcdef"},
+		{"the default branch is addressed the same way", "octocov-report", "", "0123456789abcdef", "report/report.go", "https://octocov.dev/k1LoW/octocov/file/report/report.go?artifact_name=octocov-report&commit=0123456789abcdef"},
+		{"a separator inside a name does not end the path", "octocov-report", "", "0123456789abcdef", "some dir/a#b.go", "https://octocov.dev/k1LoW/octocov/file/some%20dir/a%23b.go?artifact_name=octocov-report&commit=0123456789abcdef"},
+		{"a report of no commit links nowhere", "octocov-report", "", "", "report/report.go", ""},
+		{"a report stored in no artifact links nowhere", "", "", "0123456789abcdef", "report/report.go", ""},
+		{"a GitHub Enterprise Server run links nowhere", "octocov-report", "https://github.example.com", "0123456789abcdef", "report/report.go", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_SERVER_URL", tt.serverURL)
+			v := NewViewer(tt.artifactName)
+			got := v.fileURL(&Report{Repository: "k1LoW/octocov", Commit: tt.commit}, tt.path)
+			if got != tt.want {
+				t.Errorf("got %v\nwant %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinkCell(t *testing.T) {
+	if got, want := linkCell("82.3%", ""), "82.3%"; got != want {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+	if got, want := linkCell("82.3%", "https://octocov.dev/o/r/pull/1"), "[82.3%](https://octocov.dev/o/r/pull/1)"; got != want {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}

--- a/report/viewer_test.go
+++ b/report/viewer_test.go
@@ -41,22 +41,21 @@ func TestViewerFileURL(t *testing.T) {
 		name         string
 		artifactName string
 		serverURL    string
-		commit       string
 		path         string
 		want         string
 	}{
-		{"a file is named by the artifact holding its report", "octocov-report@refs_pull_722", "", "0123456789abcdef", "report/report.go", "https://octocov.dev/k1LoW/octocov/file/report/report.go?artifact_name=octocov-report%40refs_pull_722&commit=0123456789abcdef"},
-		{"the default branch is addressed the same way", "octocov-report", "", "0123456789abcdef", "report/report.go", "https://octocov.dev/k1LoW/octocov/file/report/report.go?artifact_name=octocov-report&commit=0123456789abcdef"},
-		{"a separator inside a name does not end the path", "octocov-report", "", "0123456789abcdef", "some dir/a#b.go", "https://octocov.dev/k1LoW/octocov/file/some%20dir/a%23b.go?artifact_name=octocov-report&commit=0123456789abcdef"},
-		{"a report of no commit links nowhere", "octocov-report", "", "", "report/report.go", ""},
-		{"a report stored in no artifact links nowhere", "", "", "0123456789abcdef", "report/report.go", ""},
-		{"a GitHub Enterprise Server run links nowhere", "octocov-report", "https://github.example.com", "0123456789abcdef", "report/report.go", ""},
+		{"a file is named by the artifact holding its report", "octocov-report@refs_pull_722", "", "report/report.go", "https://octocov.dev/k1LoW/octocov/file/report/report.go?artifact_name=octocov-report%40refs_pull_722"},
+		{"the default branch is addressed the same way", "octocov-report", "", "report/report.go", "https://octocov.dev/k1LoW/octocov/file/report/report.go?artifact_name=octocov-report"},
+		{"a separator inside a name does not end the path", "octocov-report", "", "some dir/a#b.go", "https://octocov.dev/k1LoW/octocov/file/some%20dir/a%23b.go?artifact_name=octocov-report"},
+		{"an empty path links nowhere", "octocov-report", "", "", ""},
+		{"a report stored in no artifact links nowhere", "", "", "report/report.go", ""},
+		{"a GitHub Enterprise Server run links nowhere", "octocov-report", "https://github.example.com", "report/report.go", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("GITHUB_SERVER_URL", tt.serverURL)
 			v := NewViewer(tt.artifactName)
-			got := v.fileURL(&Report{Repository: "k1LoW/octocov", Commit: tt.commit}, tt.path)
+			got := v.fileURL(&Report{Repository: "k1LoW/octocov", Commit: "0123456789abcdef"}, tt.path)
 			if got != tt.want {
 				t.Errorf("got %v\nwant %v", got, tt.want)
 			}


### PR DESCRIPTION
## Summary

- **The comment carries a coverage percentage with nothing behind it.** The file names link to the source on GitHub, but the number describing their coverage is plain text, and until #720 there was nowhere for it to point: the report of a pull request was not stored, so nothing could address it. It is now, k1LoW/octocov.dev#16 serves a page for it, and this is the link that closes the loop.
- **The coverage values are linked rather than the file names**, so the source stays one click away and the two links say different things. Each overall value opens the report of the ref it describes, and each file value opens that file.

```
| Coverage | Code to Test Ratio | Test Execution Time |
| [82.3%](https://octocov.dev/k1LoW/octocov/pull/722) | 1:0.5 | 4m40s |

|              | main (1234567) | feat/x (89abcde) | +/- |
| **Coverage** | [81.1%](https://octocov.dev/k1LoW/octocov) | [82.3%](https://octocov.dev/k1LoW/octocov/pull/722) | +1.2% |

| Files | Coverage | +/- | Status |
| [report/report.go](https://github.com/.../blob/<sha>/report/report.go) | [76.4%](https://octocov.dev/k1LoW/octocov/file/report/report.go?artifact_name=octocov-report%40refs_pull_722) | +1.2% | modified |
```

- **The report page is routed by the ref, which is the key #720 already derives.** An empty key is the report of the default branch, which the viewer serves as the repository itself, so both columns of the comparison table link, a push to the default branch links its summary, and a branch build links at its own tree page. A tag has none.
- **A file is addressed differently, because the viewer is.** There is no per-file page under the pull request path, so a file names the artifact holding its report in the query instead, and that name is the whole of what the page needs. That is the whole reason `datastore.ArtifactName` exists here rather than the name being composed inline.
- **The artifact name is composed by the code that writes it.** `Artifact.StoreName` was already deriving `<base>@refs_pull_<n>` for storing, and composing it a second time for the link would let the two drift, with the ref suffix being exactly the part that is easy to get subtly wrong. The link asks the configured datastore list for the name instead, and a configuration storing the report anywhere else answers that it has none.

## Where to look

`report/viewer.go` is the whole of the URL shaping and the conditions under which there is no URL. Everything else is the plumbing that reaches it: a `*Viewer` parameter on the four markdown table renderers, `nil` at the two terminal call sites, and `storedArtifactViewer` in `cmd/root.go` resolving one for the run. A nil `Viewer` renders every cell exactly as before, which is why no cell needed a branch of its own.

## Decisions worth arguing about

- **On by default, off by `hideCoverageLink:`.** A value that opens the coverage it describes is what the comment was missing, and a configuration that does not store to an artifact never sees the links anyway, so the flag only has to answer the case of not wanting them. It sits beside `hideFooterLink:` under each of `comment:`, `summary:` and `body:` and reads the same way.
- **The links are gated on the run storing a report, not on a datastore being configured.** Gating on the datastore list alone linked every pull request of a configuration carrying `report.if: is_default_branch`, which is what the README points `github://` users at, at an artifact that run then skipped writing. `ReportConfigReady()` is the same readiness the storing uses, so the two cannot disagree.
- **A GitHub Enterprise Server run gets no links.** The pages read the artifacts through the github.com API, so `GITHUB_SERVER_URL` naming anything else means there is nothing for them to show.
- **The comment is written before the artifact is uploaded**, since storing happens after the three outputs in `cmd/root.go`. The link therefore names an artifact that appears moments later, and one that never appears if storing fails. Reordering the pipeline to close that window looked worse than the window itself.
- **A report of a repository sub-directory links to its repository page.** The viewer is routed by owner and repository only, and the sub-directory is carried in the artifact name, so the file links resolve while the report page shows the repository's own report.

Closes #625

