### PR TITLE
fix: link the compared coverage only when it came from an artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ diff:
 
 ![img](docs/comment_with_diff.png)
 
-When the report is stored in a GitHub Actions artifact, the coverage values of the comment link to [octocov.dev](https://octocov.dev/), where the stored report can be browsed. Each overall coverage opens the report of the ref it describes, so the compared column opens the default branch and the current one opens the pull request, and the coverage of each file opens that file. The file names keep pointing at the source on GitHub. Set `comment.hideCoverageLink:` ( or the same key under `summary:` or `body:` ) to render them as plain values again.
+When the report is stored in a GitHub Actions artifact, the coverage values of the comment link to [octocov.dev](https://octocov.dev/), where the stored report can be browsed. Each overall coverage opens the report of the ref it describes, so the compared column opens the default branch and the current one opens the pull request, and the coverage of each file opens that file. The compared column is linked only when `diff.datastores:` read it out of an artifact, since that is what the page it would open serves. The file names keep pointing at the source on GitHub. Set `comment.hideCoverageLink:` ( or the same key under `summary:` or `body:` ) to render them as plain values again.
 
 ### Check for acceptable score
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ diff:
 
 ![img](docs/comment_with_diff.png)
 
-When the report is stored in a GitHub Actions artifact, the coverage values of the comment link to [octocov.dev](https://octocov.dev/), where the stored report can be browsed. Each overall coverage opens the report of the ref it describes, so the compared column opens the default branch and the current one opens the pull request, and the coverage of each file opens that file. The compared column is linked only when `diff.datastores:` read it out of an artifact, since that is what the page it would open serves. The file names keep pointing at the source on GitHub. Set `comment.hideCoverageLink:` ( or the same key under `summary:` or `body:` ) to render them as plain values again.
+When the report is stored in a GitHub Actions artifact, the coverage values of the comment link to [octocov.dev](https://octocov.dev/), where the stored report can be browsed. Each overall coverage opens the report of the ref it describes, so the compared column opens the default branch and the current one opens the pull request, and the coverage of each file opens that file. The compared column is linked only when `diff.datastores:` read it out of an artifact, since that is what the page it would open serves, and no column is linked at all unless this run stores its own report in one. The file names keep pointing at the source on GitHub. Set `comment.hideCoverageLink:` ( or the same key under `summary:` or `body:` ) to render them as plain values again.
 
 ### Check for acceptable score
 

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -45,8 +45,9 @@ func commentReport(ctx context.Context, c *config.Config, content, key string) e
 // createReportContent renders the report for one of the pull request outputs. files is the
 // changed file list, fetched by the caller so that the three outputs and the patch coverage
 // measurement share one paginated fetch instead of repeating it. v links the coverage cells
-// to the pages that browse the stored report, and is nil when there are none to link to.
-func createReportContent(c *config.Config, r, rPrev *report.Report, files []*gh.PullRequestFile, message string, hideFooterLink bool, v *report.Viewer) (string, error) {
+// to the pages that browse the stored report, vPrev does the same for the report being
+// compared against, and either is nil when there is no page to link at.
+func createReportContent(c *config.Config, r, rPrev *report.Report, files []*gh.PullRequestFile, message string, hideFooterLink bool, v, vPrev *report.Viewer) (string, error) {
 	footer := "Reported by [octocov](https://github.com/k1LoW/octocov)"
 	if hideFooterLink {
 		footer = "Reported by octocov"
@@ -57,7 +58,7 @@ func createReportContent(c *config.Config, r, rPrev *report.Report, files []*gh.
 	)
 	if rPrev != nil {
 		d := r.Compare(rPrev)
-		table = d.Table(v)
+		table = d.Table(v, vPrev)
 		relWd := c.Root()
 		if c.GitRoot != "" {
 			if rw, err := filepath.Rel(c.GitRoot, c.Root()); err == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -323,6 +323,10 @@ var rootCmd = &cobra.Command{
 
 		// Get previous report for comparing reports
 		var rPrev *report.Report
+		// comparedArtifact names the artifact rPrev was read out of, and stays empty when it
+		// was read from anywhere else. The pages serve what an artifact holds, so a
+		// comparison that did not come from one has no page describing it to link at.
+		var comparedArtifact string
 		if err := c.DiffConfigReady(); err == nil {
 			log.Println("Get previous report for comparing reports")
 			repo, err := gh.Parse(c.Repository)
@@ -375,6 +379,7 @@ var rootCmd = &cobra.Command{
 				// Select latest report
 				if rPrev == nil || rPrev.Timestamp.UnixNano() < rt.Timestamp.UnixNano() {
 					rPrev = rt
+					comparedArtifact, _ = datastore.ArtifactName([]string{s}, rt)
 				}
 			}
 			if c.Diff.Path != "" {
@@ -385,6 +390,9 @@ var rootCmd = &cobra.Command{
 				if err := rt.MeasureCoverage([]string{c.Diff.Path}, c.Coverage.Exclude); err == nil {
 					if rPrev == nil || rPrev.Timestamp.UnixNano() < rt.Timestamp.UnixNano() {
 						rPrev = rt
+						// Measured here rather than read out of an artifact, and it wins on
+						// timestamp whenever both are configured.
+						comparedArtifact = ""
 					}
 				}
 			}
@@ -402,11 +410,11 @@ var rootCmd = &cobra.Command{
 		storedArtifact := sync.OnceValue(func() *report.Viewer {
 			return storedArtifactViewer(c, r)
 		})
-		coverageViewer := func(hide bool) *report.Viewer {
+		coverageViewers := func(hide bool) (cur, prev *report.Viewer) {
 			if hide {
-				return nil
+				return nil, nil
 			}
-			return storedArtifact()
+			return storedArtifact(), report.NewViewer(comparedArtifact)
 		}
 
 		// Comment report to pull request
@@ -425,7 +433,8 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Comment.Message, c.Comment.HideFooterLink, coverageViewer(c.Comment.HideCoverageLink))
+				cur, prev := coverageViewers(c.Comment.HideCoverageLink)
+				content, err := createReportContent(c, r, rPrev, files, c.Comment.Message, c.Comment.HideFooterLink, cur, prev)
 				if err != nil {
 					return err
 				}
@@ -454,7 +463,8 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Summary.Message, c.Summary.HideFooterLink, coverageViewer(c.Summary.HideCoverageLink))
+				cur, prev := coverageViewers(c.Summary.HideCoverageLink)
+				content, err := createReportContent(c, r, rPrev, files, c.Summary.Message, c.Summary.HideFooterLink, cur, prev)
 				if err != nil {
 					return err
 				}
@@ -483,7 +493,8 @@ var rootCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				content, err := createReportContent(c, r, rPrev, files, c.Body.Message, c.Body.HideFooterLink, coverageViewer(c.Body.HideCoverageLink))
+				cur, prev := coverageViewers(c.Body.HideCoverageLink)
+				content, err := createReportContent(c, r, rPrev, files, c.Body.Message, c.Body.HideFooterLink, cur, prev)
 				if err != nil {
 					return err
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -414,7 +414,7 @@ var rootCmd = &cobra.Command{
 			if hide {
 				return nil, nil
 			}
-			return storedArtifact(), report.NewViewer(comparedArtifact)
+			return viewersFor(storedArtifact(), comparedArtifact)
 		}
 
 		// Comment report to pull request
@@ -685,6 +685,17 @@ func storedArtifactViewer(c *config.Config, r *report.Report) *report.Viewer {
 		return nil
 	}
 	return report.NewViewer(name)
+}
+
+// viewersFor pairs the viewer of the report being described with the one of the report it
+// is compared against. The compared side follows the current one, so that a link appears
+// only on a run that stores a report in an artifact of its own, and then only when the
+// comparison was read out of an artifact too.
+func viewersFor(stored *report.Viewer, comparedArtifact string) (cur, prev *report.Viewer) {
+	if stored == nil {
+		return nil, nil
+	}
+	return stored, report.NewViewer(comparedArtifact)
 }
 
 func reportToDatastores(ctx context.Context, c *config.Config, datastores []string, r *report.Report) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -60,3 +60,32 @@ func TestStoredArtifactViewer(t *testing.T) {
 		})
 	}
 }
+
+func TestViewersFor(t *testing.T) {
+	stored := report.NewViewer("octocov-report@refs_pull_722")
+	tests := []struct {
+		name             string
+		stored           *report.Viewer
+		comparedArtifact string
+		wantCur          bool
+		wantPrev         bool
+	}{
+		{"both sides when both came from an artifact", stored, "octocov-report", true, true},
+		{"the compared side alone stays unlinked", stored, "", true, false},
+		// A run storing no artifact of its own links nothing, so that every link in a
+		// comment belongs to a run that wrote one.
+		{"a run storing no artifact links neither side", nil, "octocov-report", false, false},
+		{"neither side when there is nothing either way", nil, "", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cur, prev := viewersFor(tt.stored, tt.comparedArtifact)
+			if (cur != nil) != tt.wantCur {
+				t.Errorf("got cur %v\nwant one: %v", cur, tt.wantCur)
+			}
+			if (prev != nil) != tt.wantPrev {
+				t.Errorf("got prev %v\nwant one: %v", prev, tt.wantPrev)
+			}
+		})
+	}
+}

--- a/report/diff_report.go
+++ b/report/diff_report.go
@@ -57,14 +57,17 @@ func (d *DiffReport) Out(w io.Writer) {
 	b := tablewriter.Colors{tablewriter.Bold}
 
 	// No viewer, since this is the terminal output, where a markdown link is noise.
-	d.renderTable(table, g, r, b, true, false, nil)
+	d.renderTable(table, g, r, b, true, false, nil, nil)
 
 	table.Render()
 }
 
 var leftSepRe = regexp.MustCompile(`(?m)^\|`)
 
-func (d *DiffReport) Table(v *Viewer) string {
+// Table renders the comparison. cur views the report being described and prev the one it
+// is compared against, which is a viewer of its own because a comparison can be read from
+// somewhere the pages do not serve.
+func (d *DiffReport) Table(cur, prev *Viewer) string {
 	var out []string
 
 	// Markdown table
@@ -75,7 +78,7 @@ func (d *DiffReport) Table(v *Viewer) string {
 	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table.SetCenterSeparator("|")
 	table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT})
-	d.renderTable(table, tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{}, false, true, v)
+	d.renderTable(table, tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{}, false, true, cur, prev)
 	table.Render()
 	out = append(out, strings.Replace(strings.Replace(buf.String(), "---|", "--:|", 4), "--:|", "---|", 1))
 
@@ -86,7 +89,7 @@ func (d *DiffReport) Table(v *Viewer) string {
 	table2.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 	table2.SetCenterSeparator("|")
 	table2.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT})
-	d.renderTable(table2, tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{}, true, false, nil)
+	d.renderTable(table2, tablewriter.Colors{}, tablewriter.Colors{}, tablewriter.Colors{}, true, false, nil, nil)
 	table2.Render()
 	t2 := leftSepRe.ReplaceAllString(buf2.String(), "  |")
 	if d.Coverage != nil {
@@ -252,7 +255,7 @@ func (d *DiffReport) FileCoveragesTable(files []*gh.PullRequestFile, relWd strin
 	return strings.Replace(strings.Replace(buf.String(), "---|", "--:|", len(h)), "--:|", "---|", 1)
 }
 
-func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.Colors, detail bool, withLink bool, v *Viewer) {
+func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.Colors, detail bool, withLink bool, cur, prev *Viewer) {
 	if withLink {
 		table.SetHeader([]string{"", makeHeadTitleWithLink(d.RefB, d.CommitB, d.ReportB.covPaths), makeHeadTitleWithLink(d.RefA, d.CommitA, d.ReportA.covPaths), "+/-"})
 	} else {
@@ -274,10 +277,12 @@ func (d *DiffReport) renderTable(table *tablewriter.Table, g, r, b tablewriter.C
 			if !detail {
 				t = "**Coverage**"
 			}
-			// Both sides, since each report names the ref its own page is routed by.
-			prev := linkCell(fmt.Sprintf("%.1f%%", floor1(d.Coverage.B)), v.reportURL(d.ReportB))
-			cur := linkCell(fmt.Sprintf("%.1f%%", floor1(d.Coverage.A)), v.reportURL(d.ReportA))
-			table.Rich([]string{t, prev, cur, ds}, []tablewriter.Colors{b, tablewriter.Colors{}, tablewriter.Colors{}, cc})
+			// Each side by its own viewer, since each report names the ref its page is
+			// routed by, and only the compared side can have been read from somewhere the
+			// pages do not serve.
+			bc := linkCell(fmt.Sprintf("%.1f%%", floor1(d.Coverage.B)), prev.reportURL(d.ReportB))
+			ac := linkCell(fmt.Sprintf("%.1f%%", floor1(d.Coverage.A)), cur.reportURL(d.ReportA))
+			table.Rich([]string{t, bc, ac, ds}, []tablewriter.Colors{b, tablewriter.Colors{}, tablewriter.Colors{}, cc})
 		}
 		if detail && d.Coverage.CoverageA != nil && d.Coverage.CoverageB != nil {
 			{

--- a/report/diff_report_test.go
+++ b/report/diff_report_test.go
@@ -46,7 +46,7 @@ func TestDiffTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := a.Compare(b).Table(nil)
+	got := a.Compare(b).Table(nil, nil)
 	f := "diff_table"
 	if os.Getenv("UPDATE_GOLDEN") != "" {
 		golden.Update(t, testdataDir(t), f, got)
@@ -137,7 +137,7 @@ func TestDiffTableLinksBothCoveragesToTheViewer(t *testing.T) {
 	b.Ref = "refs/heads/main"
 	b.BaseRef = "refs/heads/main"
 
-	got := a.Compare(b).Table(NewViewer("octocov-report@refs_pull_722"))
+	got := a.Compare(b).Table(NewViewer("octocov-report@refs_pull_722"), NewViewer("octocov-report"))
 	for _, want := range []string{
 		"](https://octocov.dev/k1LoW/tbls/pull/722)",
 		"](https://octocov.dev/k1LoW/tbls)",
@@ -150,8 +150,18 @@ func TestDiffTableLinksBothCoveragesToTheViewer(t *testing.T) {
 	if n := strings.Count(got, "octocov.dev"); n != 2 {
 		t.Errorf("got %d links\nwant 2\n%v", n, got)
 	}
-	if strings.Contains(a.Compare(b).Table(nil), "octocov.dev") {
+	if strings.Contains(a.Compare(b).Table(nil, nil), "octocov.dev") {
 		t.Error("a nil viewer must not link to the viewer")
+	}
+
+	// The compared report can have been read from somewhere the pages do not serve, and
+	// then only the side that was stored in an artifact is linked.
+	only := a.Compare(b).Table(NewViewer("octocov-report@refs_pull_722"), nil)
+	if want := "](https://octocov.dev/k1LoW/tbls/pull/722)"; !strings.Contains(only, want) {
+		t.Errorf("got\n%v\nwant it to contain\n%v", only, want)
+	}
+	if n := strings.Count(only, "octocov.dev"); n != 1 {
+		t.Errorf("got %d links\nwant 1\n%v", n, only)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **The compared column of the comparison table was linked on the viewer of the current run.** That viewer says where this run writes its report, not where the comparison was read from, and the two are not the same artifact: the compared side is backed by one a previous default branch run wrote. #722 shipped with both columns sharing it.
- **So a configuration reading its comparison from anywhere else linked at a page that serves an artifact nothing said anything about.** `diff.datastores: [s3://…]` alongside `report.datastores: [artifact://…]` is the plain case, and `diff.path:` is the other one, where the compared value is measured from a local file and the link would open a page describing something else.
- **The compared side now carries its own provenance**, tracked where `rPrev` is chosen rather than read off the configuration. That matters because `diff.path:` is measured with `time.Now()` and wins the timestamp comparison against a stored report whenever both are set, so the configuration alone would say artifact where the value came from a file.
- **On top of that it follows the current side.** A configuration writing to `s3://` while reading its comparison from an artifact could have linked the compared column alone, and that link would even be sound, but it would break the one rule the feature can be stated by: every link in a comment belongs to an artifact the run itself wrote. `viewersFor` gives up that case to keep the rule true.

| this run stores an artifact | `rPrev` was read from | current column | compared column |
|---|---|---|---|
| yes | an artifact | linked | linked |
| yes | `s3://`, `bq://`, … | linked | plain |
| yes | `diff.path:` | linked | plain |
| no | anything | plain | plain |

`hideCoverageLink:` and a GitHub Enterprise Server run make every row plain, as before.

These two commits were written against #722 after it had already merged, so they arrive on their own rather than as part of it.