### PR TITLE
fix: parse LCOV reports with repeated SF records, checksums, and colons in paths

### DIFF
--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -72,8 +72,9 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 			fileName = splitted[1]
 		case "DA":
 			total += 1
+			// DA:<line>,<count>[,<checksum>]
 			nums := strings.Split(splitted[1], ",")
-			if len(nums) != 2 {
+			if len(nums) != 2 && len(nums) != 3 {
 				_ = r.Close() //nostyle:handlerrors
 				return nil, "", fmt.Errorf("can not parse: %s", l)
 			}

--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -49,13 +49,24 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 			fcov, err := cov.Files.FindByFile(fileName)
 			if err != nil {
 				fcov = NewFileCoverage(fileName, TypeLOC)
+				fcov.Total = total
+				fcov.Covered = covered
+				fcov.Blocks = blocks
+				cov.Total += total
+				cov.Covered += covered
+				cov.Files = append(cov.Files, fcov)
+			} else {
+				// The same source file can appear in several records (e.g. .info files of
+				// separate test runs concatenated together). Stack the blocks and count lines
+				// once, the same way Coverage.Merge does, instead of replacing the earlier
+				// record and listing the file twice.
+				fcov.Blocks = append(fcov.Blocks, blocks...)
+				lcs := fcov.Blocks.ToLineCoverages()
+				cov.Total += lcs.Total() - fcov.Total
+				cov.Covered += lcs.Covered() - fcov.Covered
+				fcov.Total = lcs.Total()
+				fcov.Covered = lcs.Covered()
 			}
-			fcov.Total += total
-			fcov.Covered += covered
-			fcov.Blocks = blocks
-			cov.Total += total
-			cov.Covered += covered
-			cov.Files = append(cov.Files, fcov)
 			total = 0
 			covered = 0
 			parsed = true

--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -62,7 +62,8 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 			blocks = BlockCoverages{}
 			continue
 		}
-		splitted := strings.Split(l, ":")
+		// The value may itself contain ':' (e.g. SF:C:\path\to\file), so split only once.
+		splitted := strings.SplitN(l, ":", 2)
 		if len(splitted) != 2 {
 			continue
 		}

--- a/coverage/lcov_test.go
+++ b/coverage/lcov_test.go
@@ -98,3 +98,40 @@ func TestLcovParseAllFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestLcovAcceptsPathContainingColon(t *testing.T) {
+	// Windows drive letters put a ':' inside the SF value.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lcov.info")
+	content := `TN:
+SF:C:\proj\src\a.ts
+DA:1,1
+end_of_record
+TN:
+SF:C:\proj\src\b.ts
+DA:1,0
+end_of_record
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewLcov().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 2; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if want := `C:\proj\src\a.ts`; got.Files[0].File != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].File, want)
+	}
+	if want := `C:\proj\src\b.ts`; got.Files[1].File != want {
+		t.Errorf("got %v\nwant %v", got.Files[1].File, want)
+	}
+	if want := 2; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 1; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+}

--- a/coverage/lcov_test.go
+++ b/coverage/lcov_test.go
@@ -135,3 +135,28 @@ end_of_record
 		t.Errorf("got %v\nwant %v", got.Covered, want)
 	}
 }
+
+func TestLcovAcceptsChecksum(t *testing.T) {
+	// DA:<line>,<count>[,<checksum>] (lcov --checksum)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lcov.info")
+	content := `TN:
+SF:src/a.ts
+DA:1,1,abcdef
+DA:2,0,abcdef
+end_of_record
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewLcov().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 2; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 1; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+}

--- a/coverage/lcov_test.go
+++ b/coverage/lcov_test.go
@@ -160,3 +160,58 @@ end_of_record
 		t.Errorf("got %v\nwant %v", got.Covered, want)
 	}
 }
+
+func TestLcovMergesRecordsOfSameFile(t *testing.T) {
+	// Concatenated .info files (e.g. one per test run) repeat SF for the same
+	// source file. The file must appear once, with counts stacked per line.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lcov.info")
+	content := `TN:
+SF:src/a.ts
+DA:1,1
+DA:2,0
+end_of_record
+TN:
+SF:src/a.ts
+DA:1,0
+DA:2,3
+DA:3,1
+end_of_record
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewLcov().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 1; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	f := got.Files[0]
+	if want := 3; f.Total != want {
+		t.Errorf("got %v\nwant %v", f.Total, want)
+	}
+	if want := 3; f.Covered != want {
+		t.Errorf("got %v\nwant %v", f.Covered, want)
+	}
+	if want := 5; len(f.Blocks) != want {
+		t.Errorf("got %v\nwant %v", len(f.Blocks), want)
+	}
+	if want := 3; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 3; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+	// Exclude() recalculates from blocks; the totals must not change.
+	if err := got.Exclude(nil); err != nil {
+		t.Fatal(err)
+	}
+	if want := 3; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 3; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+}


### PR DESCRIPTION
## Summary

- **A file named by more than one `SF:` record was listed twice and its total doubled.** On `end_of_record` the parser found the existing `FileCoverage`, then replaced its blocks with those of the later record, added the line counts on top of the earlier ones, and appended the same pointer to `Files` again. `reCalc` later walked the duplicate too, so the report total came out doubled. This is what a `lcov.info` built by concatenating the output of several test runs looks like.
- **Records of the same file are now stacked.** The blocks are appended and the lines counted once through `ToLineCoverages`, which is how `Coverage.Merge` already treats LOC blocks that pile up, so a file measured by two runs reads the same whether the runs came as one `.info` or two. The first record of a file keeps the plain `DA` count, so an `.info` without repeats parses exactly as before.
- **`DA:` lines with a checksum failed the whole report.** The format allows `DA:<line>,<count>[,<checksum>]`, which `lcov --checksum` emits, and the parser insisted on two fields. It now takes two or three and ignores the checksum.
- **An `SF:` value containing `:` was dropped.** Every line was split on all colons and skipped unless exactly two parts came back, so a Windows path such as `SF:C:\proj\src\a.ts` never set the file name and the following `DA:` lines landed on an empty name or on the previous file. Lines are now split on the first colon only.

Each fix is its own commit with a test that fails without it.

Closes #724