### PR TITLE
fix: give every map-keyed coverage parser a stable file order

### DIFF
--- a/coverage/cobertura.go
+++ b/coverage/cobertura.go
@@ -102,6 +102,8 @@ func (c *Cobertura) ParseReport(path string) (*Coverage, string, error) {
 	// A file can be split over several <class> elements (e.g. one class per inner class), so
 	// keep the order of first appearance instead of ranging over flm, whose iteration order Go
 	// randomizes and which would churn the files array of a stored report on every run.
+	// Merging through Files.FindByFile in one pass, the way lcov.go does, would drop the map,
+	// but it rescans the slice once per <class> element and this format has one per class.
 	var order []string
 	for _, p := range r.Packages.Package {
 		for _, c := range p.Classes.Class {

--- a/coverage/cobertura.go
+++ b/coverage/cobertura.go
@@ -99,12 +99,17 @@ func (c *Cobertura) ParseReport(path string) (*Coverage, string, error) {
 	cov.Format = c.Name()
 
 	flm := map[string]BlockCoverages{}
+	// A file can be split over several <class> elements (e.g. one class per inner class), so
+	// keep the order of first appearance instead of ranging over flm, whose iteration order Go
+	// randomizes and which would churn the files array of a stored report on every run.
+	order := []string{}
 	for _, p := range r.Packages.Package {
 		for _, c := range p.Classes.Class {
 			n := c.Filename
 			f, ok := flm[n]
 			if !ok {
 				f = BlockCoverages{}
+				order = append(order, n)
 			}
 			for _, l := range c.Lines.Line {
 				sl := l.Number
@@ -121,7 +126,8 @@ func (c *Cobertura) ParseReport(path string) (*Coverage, string, error) {
 		}
 	}
 
-	for f, blocks := range flm {
+	for _, f := range order {
+		blocks := flm[f]
 		fcov := NewFileCoverage(f, TypeLOC)
 		for _, b := range blocks {
 			fcov.Total += 1

--- a/coverage/cobertura.go
+++ b/coverage/cobertura.go
@@ -102,7 +102,7 @@ func (c *Cobertura) ParseReport(path string) (*Coverage, string, error) {
 	// A file can be split over several <class> elements (e.g. one class per inner class), so
 	// keep the order of first appearance instead of ranging over flm, whose iteration order Go
 	// randomizes and which would churn the files array of a stored report on every run.
-	order := []string{}
+	var order []string
 	for _, p := range r.Packages.Package {
 		for _, c := range p.Classes.Class {
 			n := c.Filename

--- a/coverage/cobertura_test.go
+++ b/coverage/cobertura_test.go
@@ -66,10 +66,18 @@ func TestCoberturaParseAllFormat(t *testing.T) {
 func TestCoberturaFilesOrder(t *testing.T) {
 	path := filepath.Join(testdataDir(t), "cobertura")
 	// The files of a parsed report follow the order the report lists them in, and stay in that
-	// order however many times the same report is parsed.
-	head := []string{"__init__.py", "applications.py", "background.py"}
+	// order however many times the same report is parsed. Sorted order would put
+	// dependencies/__init__.py sixth, so the sixth name is what tells the two apart.
+	head := []string{
+		"__init__.py",
+		"applications.py",
+		"background.py",
+		"concurrency.py",
+		"datastructures.py",
+		"encoders.py",
+	}
 	var first []string
-	for range 10 {
+	for i := range 10 {
 		cov, _, err := NewCobertura().ParseReport(path)
 		if err != nil {
 			t.Fatal(err)
@@ -78,10 +86,13 @@ func TestCoberturaFilesOrder(t *testing.T) {
 		for _, f := range cov.Files {
 			got = append(got, f.File)
 		}
+		if len(got) < len(head) {
+			t.Fatalf("got %v files\nwant at least %v", len(got), len(head))
+		}
 		if diff := cmp.Diff(got[:len(head)], head); diff != "" {
 			t.Error(diff)
 		}
-		if len(first) == 0 {
+		if i == 0 {
 			first = got
 			continue
 		}

--- a/coverage/cobertura_test.go
+++ b/coverage/cobertura_test.go
@@ -3,6 +3,8 @@ package coverage
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCobertura(t *testing.T) {
@@ -57,6 +59,34 @@ func TestCoberturaParseAllFormat(t *testing.T) {
 		_, _, err := NewCobertura().ParseReport(tt.path)
 		if tt.wantErr != (err != nil) {
 			t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
+		}
+	}
+}
+
+func TestCoberturaFilesOrder(t *testing.T) {
+	path := filepath.Join(testdataDir(t), "cobertura")
+	// The files of a parsed report follow the order the report lists them in, and stay in that
+	// order however many times the same report is parsed.
+	head := []string{"__init__.py", "applications.py", "background.py"}
+	var first []string
+	for i := 0; i < 10; i++ {
+		cov, _, err := NewCobertura().ParseReport(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []string
+		for _, f := range cov.Files {
+			got = append(got, f.File)
+		}
+		if diff := cmp.Diff(got[:len(head)], head); diff != "" {
+			t.Error(diff)
+		}
+		if first == nil {
+			first = got
+			continue
+		}
+		if diff := cmp.Diff(got, first); diff != "" {
+			t.Error(diff)
 		}
 	}
 }

--- a/coverage/cobertura_test.go
+++ b/coverage/cobertura_test.go
@@ -81,7 +81,7 @@ func TestCoberturaFilesOrder(t *testing.T) {
 		if diff := cmp.Diff(got[:len(head)], head); diff != "" {
 			t.Error(diff)
 		}
-		if first == nil {
+		if len(first) == 0 {
 			first = got
 			continue
 		}

--- a/coverage/cobertura_test.go
+++ b/coverage/cobertura_test.go
@@ -69,7 +69,7 @@ func TestCoberturaFilesOrder(t *testing.T) {
 	// order however many times the same report is parsed.
 	head := []string{"__init__.py", "applications.py", "background.py"}
 	var first []string
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		cov, _, err := NewCobertura().ParseReport(path)
 		if err != nil {
 			t.Fatal(err)

--- a/coverage/cobertura_test.go
+++ b/coverage/cobertura_test.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -99,5 +100,48 @@ func TestCoberturaFilesOrder(t *testing.T) {
 		if diff := cmp.Diff(got, first); diff != "" {
 			t.Error(diff)
 		}
+	}
+}
+
+func TestCoberturaMergesClassesOfSameFile(t *testing.T) {
+	// A file split over several <class> elements (one per inner class, say) appears once, at
+	// the position of its first element, with the lines of every element behind it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "coverage.xml")
+	content := `<?xml version="1.0" ?>
+<coverage>
+  <packages>
+    <package name="pkg">
+      <classes>
+        <class filename="a.py">
+          <lines><line number="1" hits="1"/></lines>
+        </class>
+        <class filename="b.py">
+          <lines><line number="1" hits="0"/></lines>
+        </class>
+        <class filename="a.py">
+          <lines><line number="2" hits="3"/></lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewCobertura().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var files []string
+	for _, f := range got.Files {
+		files = append(files, f.File)
+	}
+	if diff := cmp.Diff(files, []string{"a.py", "b.py"}); diff != "" {
+		t.Fatal(diff)
+	}
+	if want := 2; len(got.Files[0].Blocks) != want {
+		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
 	}
 }

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -96,12 +96,17 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 	cov.Format = c.Name()
 
 	flm := map[string]BlockCoverages{}
+	// The same source file can be listed by more than one <package> element, so keep the order
+	// of first appearance instead of ranging over flm, whose iteration order Go randomizes and
+	// which would churn the files array of a stored report on every run.
+	order := []string{}
 	for _, p := range r.Package {
 		for _, s := range p.Sourcefile {
 			n := fmt.Sprintf("%s/%s", p.Name, s.Name)
 			f, ok := flm[n]
 			if !ok {
 				f = BlockCoverages{}
+				order = append(order, n)
 			}
 			for _, l := range s.Line {
 				sl := l.Nr
@@ -121,7 +126,8 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 		}
 	}
 
-	for f, blocks := range flm {
+	for _, f := range order {
+		blocks := flm[f]
 		fcov := NewFileCoverage(f, TypeLOC)
 		for _, b := range blocks {
 			fcov.Total += 1

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -96,9 +96,10 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 	cov.Format = c.Name()
 
 	flm := map[string]BlockCoverages{}
-	// The same source file can be listed by more than one <package> element, so keep the order
-	// of first appearance instead of ranging over flm, whose iteration order Go randomizes and
-	// which would churn the files array of a stored report on every run.
+	// The package name is part of the key, so a key repeats only when the same <package> name
+	// appears more than once, as in a report aggregated from several modules. Keep the order of
+	// first appearance instead of ranging over flm, whose iteration order Go randomizes, which
+	// would churn the files array of a stored report on every run.
 	var order []string
 	for _, p := range r.Package {
 		for _, s := range p.Sourcefile {

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -99,7 +99,7 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 	// The same source file can be listed by more than one <package> element, so keep the order
 	// of first appearance instead of ranging over flm, whose iteration order Go randomizes and
 	// which would churn the files array of a stored report on every run.
-	order := []string{}
+	var order []string
 	for _, p := range r.Package {
 		for _, s := range p.Sourcefile {
 			n := fmt.Sprintf("%s/%s", p.Name, s.Name)

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -99,7 +99,9 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 	// The package name is part of the key, so a key repeats only when the same <package> name
 	// appears more than once, as in a report aggregated from several modules. Keep the order of
 	// first appearance instead of ranging over flm, whose iteration order Go randomizes, which
-	// would churn the files array of a stored report on every run.
+	// would churn the files array of a stored report on every run. Merging through
+	// Files.FindByFile in one pass, the way lcov.go does, would drop the map, but it rescans
+	// the slice once per <sourcefile> element.
 	var order []string
 	for _, p := range r.Package {
 		for _, s := range p.Sourcefile {

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -95,5 +96,47 @@ func TestJacocoFilesOrder(t *testing.T) {
 		if diff := cmp.Diff(got, first); diff != "" {
 			t.Error(diff)
 		}
+	}
+}
+
+func TestJacocoMergesPackagesOfSameName(t *testing.T) {
+	// A report aggregated from several modules can carry the same <package> name twice. The
+	// files it names appear once, at the position of their first element, with the lines of
+	// every element behind them.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jacocoTestReport.xml")
+	content := `<?xml version="1.0" ?>
+<report name="agg">
+  <package name="org/example">
+    <sourcefile name="A.kt">
+      <line nr="1" mi="0" ci="1"/>
+    </sourcefile>
+    <sourcefile name="B.kt">
+      <line nr="1" mi="1" ci="0"/>
+    </sourcefile>
+  </package>
+  <package name="org/example">
+    <sourcefile name="A.kt">
+      <line nr="2" mi="0" ci="3"/>
+    </sourcefile>
+  </package>
+</report>
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewJacoco().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var files []string
+	for _, f := range got.Files {
+		files = append(files, f.File)
+	}
+	if diff := cmp.Diff(files, []string{"org/example/A.kt", "org/example/B.kt"}); diff != "" {
+		t.Fatal(diff)
+	}
+	if want := 2; len(got.Files[0].Blocks) != want {
+		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
 	}
 }

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -66,13 +66,14 @@ func TestJacocoParseAllFormat(t *testing.T) {
 func TestJacocoFilesOrder(t *testing.T) {
 	path := filepath.Join(testdataDir(t), "jacoco")
 	// The files of a parsed report follow the order the report lists them in, and stay in that
-	// order however many times the same report is parsed.
+	// order however many times the same report is parsed. Sorted order would start at
+	// io/cloudevents/cloudEventsExtensions.kt, so these two names rule sorting out.
 	head := []string{
 		"org/http4k/security/oauth/server/accesstoken/GenerateAccessTokenForGrantType.kt",
 		"org/http4k/security/oauth/server/accesstoken/GrantConfiguration.kt",
 	}
 	var first []string
-	for range 10 {
+	for i := range 10 {
 		cov, _, err := NewJacoco().ParseReport(path)
 		if err != nil {
 			t.Fatal(err)
@@ -81,10 +82,13 @@ func TestJacocoFilesOrder(t *testing.T) {
 		for _, f := range cov.Files {
 			got = append(got, f.File)
 		}
+		if len(got) < len(head) {
+			t.Fatalf("got %v files\nwant at least %v", len(got), len(head))
+		}
 		if diff := cmp.Diff(got[:len(head)], head); diff != "" {
 			t.Error(diff)
 		}
-		if len(first) == 0 {
+		if i == 0 {
 			first = got
 			continue
 		}

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -84,7 +84,7 @@ func TestJacocoFilesOrder(t *testing.T) {
 		if diff := cmp.Diff(got[:len(head)], head); diff != "" {
 			t.Error(diff)
 		}
-		if first == nil {
+		if len(first) == 0 {
 			first = got
 			continue
 		}

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -3,6 +3,8 @@ package coverage
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestJacoco(t *testing.T) {
@@ -57,6 +59,37 @@ func TestJacocoParseAllFormat(t *testing.T) {
 		_, _, err := NewJacoco().ParseReport(tt.path)
 		if tt.wantErr != (err != nil) {
 			t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
+		}
+	}
+}
+
+func TestJacocoFilesOrder(t *testing.T) {
+	path := filepath.Join(testdataDir(t), "jacoco")
+	// The files of a parsed report follow the order the report lists them in, and stay in that
+	// order however many times the same report is parsed.
+	head := []string{
+		"org/http4k/security/oauth/server/accesstoken/GenerateAccessTokenForGrantType.kt",
+		"org/http4k/security/oauth/server/accesstoken/GrantConfiguration.kt",
+	}
+	var first []string
+	for i := 0; i < 10; i++ {
+		cov, _, err := NewJacoco().ParseReport(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []string
+		for _, f := range cov.Files {
+			got = append(got, f.File)
+		}
+		if diff := cmp.Diff(got[:len(head)], head); diff != "" {
+			t.Error(diff)
+		}
+		if first == nil {
+			first = got
+			continue
+		}
+		if diff := cmp.Diff(got, first); diff != "" {
+			t.Error(diff)
 		}
 	}
 }

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -72,7 +72,7 @@ func TestJacocoFilesOrder(t *testing.T) {
 		"org/http4k/security/oauth/server/accesstoken/GrantConfiguration.kt",
 	}
 	var first []string
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		cov, _, err := NewJacoco().ParseReport(path)
 		if err != nil {
 			t.Fatal(err)

--- a/coverage/simplecov.go
+++ b/coverage/simplecov.go
@@ -2,8 +2,10 @@ package coverage
 
 import (
 	"errors"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/goccy/go-json"
 )
@@ -71,8 +73,14 @@ func (s *Simplecov) ParseReport(path string) (*Coverage, string, error) {
 	cov.Format = s.Name()
 	fcovs := map[string]*FileCoverage{}
 	sls := skipLines{}
-	for _, c := range r {
-		for fn, fc := range c.Coverage {
+	// The report is a JSON object, so both the suites and the files reach us as maps and have
+	// no order of their own for Files to follow. Walk them by name, since Go randomizes map
+	// iteration and the resulting order is stored as is in report.json, reordering the whole
+	// array on every run of a byte-identical report.
+	for _, sn := range slices.Sorted(maps.Keys(r)) {
+		c := r[sn]
+		for _, fn := range slices.Sorted(maps.Keys(c.Coverage)) {
+			fc := c.Coverage[fn]
 			fcov, ok := fcovs[fn]
 			if !ok {
 				fcov = NewFileCoverage(fn, TypeLOC)

--- a/coverage/simplecov_test.go
+++ b/coverage/simplecov_test.go
@@ -2,7 +2,10 @@ package coverage
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSimplecov(t *testing.T) {
@@ -87,6 +90,33 @@ func TestSimplecovParseAllFormat(t *testing.T) {
 		_, _, err := NewSimplecov().ParseReport(tt.path)
 		if tt.wantErr != (err != nil) {
 			t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
+		}
+	}
+}
+
+func TestSimplecovFilesOrder(t *testing.T) {
+	path := filepath.Join(testdataDir(t), "simplecov")
+	// A .resultset.json is a JSON object, so it fixes no order for its files. They come out
+	// sorted by name, the same order however many times the same report is parsed.
+	var first []string
+	for i := range 10 {
+		cov, _, err := NewSimplecov().ParseReport(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got []string
+		for _, f := range cov.Files {
+			got = append(got, f.File)
+		}
+		if diff := cmp.Diff(got, slices.Sorted(slices.Values(got))); diff != "" {
+			t.Error(diff)
+		}
+		if i == 0 {
+			first = got
+			continue
+		}
+		if diff := cmp.Diff(got, first); diff != "" {
+			t.Error(diff)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **The files of a Cobertura, JaCoCo or SimpleCov report came out in a different order on every parse.** Cobertura and JaCoCo accumulate blocks into a `map[string]BlockCoverages` keyed by file name and then build `Coverage.Files` by ranging over that map, and Go randomizes map iteration order. Parsing the checked-in fixture twelve times gave twelve distinct orders.
- **Nothing rendered is affected, the stored report is.** `ls-files` sorts before printing and the comment tables are built from the changed files, but `files` is a JSON array in `report.json`, so a `report.datastores:` pointing at `github://owner/repo@branch/path` committed a reordering of the whole list on every run with no coverage value having changed, and the same order lands in `s3://`, `gs://` and `local://`.
- **Cobertura and JaCoCo now preserve the order the report lists its files in**, by recording each name on first sight and building `Files` from that slice. Sorting would have been stable too, but following the report keeps the stored array in the shape the tool that produced it chose, which is what Go cover, LCOV and Clover already do.
- **SimpleCov was affected as well, which #727 got wrong.** It does append on first sight, but what it iterates is the decoded `.resultset.json`, whose suites and files are both maps, so first sight is randomized too. A JSON object fixes no order to follow, so both maps are now walked by name rather than a document order the report does not have. That also settles the order the blocks of a file stack in when several suites measure it.
- A file can be named by more than one element in either XML format, a Cobertura `<class>` per inner class and a JaCoCo `<sourcefile>` under a repeated `<package>` name, so the blocks still merge under one key and only the first appearance fixes the position. Both cases now have a test, written inline the way the LCOV repeated-record test of #725 writes its own.

Closes #727