### PR TITLE
fix: count a line once when two Cobertura classes share a filename

### DIFF
--- a/coverage/cobertura.go
+++ b/coverage/cobertura.go
@@ -131,13 +131,14 @@ func (c *Cobertura) ParseReport(path string) (*Coverage, string, error) {
 	for _, f := range order {
 		blocks := flm[f]
 		fcov := NewFileCoverage(f, TypeLOC)
-		for _, b := range blocks {
-			fcov.Total += 1
-			if *b.Count > 0 {
-				fcov.Covered += 1
-			}
-		}
 		fcov.Blocks = blocks
+		// Two <class> elements of one file can both list the same line (a Kotlin or Scala
+		// lambda shows up under its outer class and under a synthetic one), so fold the
+		// blocks per line the way Coverage.reCalc does. Counting one line per block would
+		// count such a line twice and return a total the blocks do not support.
+		lcs := blocks.ToLineCoverages()
+		fcov.Total = lcs.Total()
+		fcov.Covered = lcs.Covered()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered
 		cov.Files = append(cov.Files, fcov)

--- a/coverage/cobertura_test.go
+++ b/coverage/cobertura_test.go
@@ -145,3 +145,55 @@ func TestCoberturaMergesClassesOfSameFile(t *testing.T) {
 		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
 	}
 }
+
+func TestCoberturaCountsSharedLineOnce(t *testing.T) {
+	// A line listed under two <class> elements of one file counts once, and counts as covered
+	// when any of those elements records a hit. The file below has three distinct lines, of
+	// which 1 and 2 were executed, and line 1 is listed under both classes.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "coverage.xml")
+	content := `<?xml version="1.0" ?>
+<coverage>
+  <packages>
+    <package name="com.example">
+      <classes>
+        <class filename="com/example/Foo.kt" name="Foo">
+          <lines>
+            <line number="1" hits="1"/>
+            <line number="2" hits="1"/>
+          </lines>
+        </class>
+        <class filename="com/example/Foo.kt" name="Foo.bar.1">
+          <lines>
+            <line number="1" hits="0"/>
+            <line number="3" hits="0"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewCobertura().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 3; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 2; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+	if want := 1; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if want := 3; got.Files[0].Total != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].Total, want)
+	}
+	if want := 2; got.Files[0].Covered != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].Covered, want)
+	}
+}

--- a/coverage/cobertura_test.go
+++ b/coverage/cobertura_test.go
@@ -196,4 +196,9 @@ func TestCoberturaCountsSharedLineOnce(t *testing.T) {
 	if want := 2; got.Files[0].Covered != want {
 		t.Errorf("got %v\nwant %v", got.Files[0].Covered, want)
 	}
+	// The blocks keep every listed line, so the totals came from folding them rather than
+	// from an append that dropped the repeat.
+	if want := 4; len(got.Files[0].Blocks) != want {
+		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
+	}
 }

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -132,13 +132,13 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 	for _, f := range order {
 		blocks := flm[f]
 		fcov := NewFileCoverage(f, TypeLOC)
-		for _, b := range blocks {
-			fcov.Total += 1
-			if *b.Count > 0 {
-				fcov.Covered += 1
-			}
-		}
 		fcov.Blocks = blocks
+		// A <sourcefile> lists each line once, but a repeated <package> name brings the same
+		// file back with lines that may repeat, so fold the blocks per line the way
+		// Coverage.reCalc does rather than counting one line per block.
+		lcs := blocks.ToLineCoverages()
+		fcov.Total = lcs.Total()
+		fcov.Covered = lcs.Covered()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered
 		cov.Files = append(cov.Files, fcov)

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -140,3 +140,49 @@ func TestJacocoMergesPackagesOfSameName(t *testing.T) {
 		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
 	}
 }
+
+func TestJacocoCountsSharedLineOnce(t *testing.T) {
+	// A repeated <package> name can bring the same file back with a line it already listed.
+	// That line counts once, and counts as covered when any of the elements records a hit. The
+	// file below has three distinct lines, of which 1 and 2 were executed.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jacocoTestReport.xml")
+	content := `<?xml version="1.0" ?>
+<report name="agg">
+  <package name="org/example">
+    <sourcefile name="A.kt">
+      <line nr="1" mi="0" ci="1"/>
+      <line nr="2" mi="0" ci="1"/>
+    </sourcefile>
+  </package>
+  <package name="org/example">
+    <sourcefile name="A.kt">
+      <line nr="1" mi="1" ci="0"/>
+      <line nr="3" mi="1" ci="0"/>
+    </sourcefile>
+  </package>
+</report>
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewJacoco().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 3; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 2; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+	if want := 1; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if want := 3; got.Files[0].Total != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].Total, want)
+	}
+	if want := 2; got.Files[0].Covered != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].Covered, want)
+	}
+}

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -185,4 +185,9 @@ func TestJacocoCountsSharedLineOnce(t *testing.T) {
 	if want := 2; got.Files[0].Covered != want {
 		t.Errorf("got %v\nwant %v", got.Files[0].Covered, want)
 	}
+	// The blocks keep every listed line, so the totals came from folding them rather than
+	// from an append that dropped the repeat.
+	if want := 4; len(got.Files[0].Blocks) != want {
+		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
+	}
 }


### PR DESCRIPTION
## Summary

- **A line listed under two `<class>` elements of one Cobertura file was counted twice.** The parser appends every `<line>` of every class into one flat `BlockCoverages` under the file name and then counts one line per block, so `Coverage.Total` for the file exceeded the number of distinct lines it has. A Kotlin or Scala file compiled to several JVM classes is the usual case, where the class declaration line or a line holding a lambda is listed under both the outer class and a synthetic one.
- **This is latent rather than user-visible, and the fix is about what the parser returns.** `MeasureCoverage` always ends in `reCalc`, which folds the blocks per line through `ToLineCoverages`, so every number reaching a comment, a badge or a stored report had already been repaired. What was wrong is the total `ParseReport` hands back, which did not agree with the blocks handed back beside it, and `coverage` is an importable package whose `Processor` is exported.
- **Both parsers now count the way `reCalc` does**, folding the assembled blocks once per file instead of incrementing per block. Deduplicating in the append was the alternative, and the fold wins because it is what decides the number everywhere else and it already sums the counts of a line, so a line hit under one class and missed under another reads as covered rather than as whichever element came last. Reports whose lines do not overlap parse to exactly the numbers they did before.
- **JaCoCo gets the same fold**, in its own commit. It was correct only because `<sourcefile>` lists each line once, which is a property of the report and not of the counting, and #730 already documented that its map key repeats when a report aggregated from several modules names one `<package>` twice. Such a report brings a file back with lines it has already listed, and those were double counted too.

Each commit carries the report from the issue as an inline test, written the way the repeated-record tests of #725 and #730 write theirs, and each test fails without its fix.

Closes #728