### PR TITLE
fix: count an LCOV line once when a record repeats a DA: line

### DIFF
--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -50,15 +50,11 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 			}
 			// The same source file can appear in several records (e.g. .info files of
 			// separate test runs concatenated together), and a single record can list the
-			// same line more than once. Stack the blocks and fold them per line the way
-			// Coverage.reCalc does, instead of replacing the earlier record or counting one
-			// line per DA:.
+			// same line more than once. Stack the blocks on the file already found rather
+			// than listing it twice, then fold them per line once after EOF the way
+			// Coverage.reCalc and the other LOC parsers do, rather than re-folding the
+			// blocks accumulated so far on every record.
 			fcov.Blocks = append(fcov.Blocks, blocks...)
-			lcs := fcov.Blocks.ToLineCoverages()
-			cov.Total += lcs.Total() - fcov.Total
-			cov.Covered += lcs.Covered() - fcov.Covered
-			fcov.Total = lcs.Total()
-			fcov.Covered = lcs.Covered()
 			parsed = true
 			blocks = BlockCoverages{}
 			continue
@@ -110,6 +106,13 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 	}
 	if !parsed {
 		return nil, "", errors.New("can not parse")
+	}
+	for _, fcov := range cov.Files {
+		lcs := fcov.Blocks.ToLineCoverages()
+		fcov.Total = lcs.Total()
+		fcov.Covered = lcs.Covered()
+		cov.Total += fcov.Total
+		cov.Covered += fcov.Covered
 	}
 	return cov, rp, nil
 }

--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -50,10 +50,9 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 			}
 			// The same source file can appear in several records (e.g. .info files of
 			// separate test runs concatenated together), and a single record can list the
-			// same line more than once. Stack the blocks on the file already found rather
-			// than listing it twice, then fold them per line once after EOF the way
-			// Coverage.reCalc and the other LOC parsers do, rather than re-folding the
-			// blocks accumulated so far on every record.
+			// same line more than once. Stack the blocks on the file already found, the way
+			// Coverage.Merge does, instead of replacing the earlier record and listing the
+			// file twice.
 			fcov.Blocks = append(fcov.Blocks, blocks...)
 			parsed = true
 			blocks = BlockCoverages{}
@@ -107,6 +106,10 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 	if !parsed {
 		return nil, "", errors.New("can not parse")
 	}
+	// Fold per line the way Coverage.reCalc does rather than counting one line per block,
+	// which would count a line twice when a record repeats it. Folding here once rather
+	// than on every end_of_record keeps a file named by R records from being re-folded R
+	// times.
 	for _, fcov := range cov.Files {
 		lcs := fcov.Blocks.ToLineCoverages()
 		fcov.Total = lcs.Total()

--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -34,10 +34,7 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 		return nil, "", err
 	}
 	scanner := bufio.NewScanner(r)
-	var (
-		fileName       string
-		total, covered int
-	)
+	var fileName string
 	cov := New()
 	cov.Type = TypeLOC
 	cov.Format = l.Name()
@@ -49,26 +46,19 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 			fcov, err := cov.Files.FindByFile(fileName)
 			if err != nil {
 				fcov = NewFileCoverage(fileName, TypeLOC)
-				fcov.Total = total
-				fcov.Covered = covered
-				fcov.Blocks = blocks
-				cov.Total += total
-				cov.Covered += covered
 				cov.Files = append(cov.Files, fcov)
-			} else {
-				// The same source file can appear in several records (e.g. .info files of
-				// separate test runs concatenated together). Stack the blocks and count lines
-				// once, the same way Coverage.Merge does, instead of replacing the earlier
-				// record and listing the file twice.
-				fcov.Blocks = append(fcov.Blocks, blocks...)
-				lcs := fcov.Blocks.ToLineCoverages()
-				cov.Total += lcs.Total() - fcov.Total
-				cov.Covered += lcs.Covered() - fcov.Covered
-				fcov.Total = lcs.Total()
-				fcov.Covered = lcs.Covered()
 			}
-			total = 0
-			covered = 0
+			// The same source file can appear in several records (e.g. .info files of
+			// separate test runs concatenated together), and a single record can list the
+			// same line more than once. Stack the blocks and fold them per line the way
+			// Coverage.reCalc does, instead of replacing the earlier record or counting one
+			// line per DA:.
+			fcov.Blocks = append(fcov.Blocks, blocks...)
+			lcs := fcov.Blocks.ToLineCoverages()
+			cov.Total += lcs.Total() - fcov.Total
+			cov.Covered += lcs.Covered() - fcov.Covered
+			fcov.Total = lcs.Total()
+			fcov.Covered = lcs.Covered()
 			parsed = true
 			blocks = BlockCoverages{}
 			continue
@@ -82,7 +72,6 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 		case "SF":
 			fileName = splitted[1]
 		case "DA":
-			total += 1
 			// DA:<line>,<count>[,<checksum>]
 			nums := strings.Split(splitted[1], ",")
 			if len(nums) != 2 && len(nums) != 3 {
@@ -104,9 +93,6 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 			if err != nil && !errors.Is(err, strconv.ErrRange) {
 				_ = r.Close() //nostyle:handlerrors
 				return nil, "", err
-			}
-			if count > 0 {
-				covered += 1
 			}
 			c := ExecCount(count)
 			blocks = append(blocks, &BlockCoverage{

--- a/coverage/lcov_test.go
+++ b/coverage/lcov_test.go
@@ -246,7 +246,8 @@ end_of_record
 	if want := 2; f.Covered != want {
 		t.Errorf("got %v\nwant %v", f.Covered, want)
 	}
-	// The blocks are left as read, so all three DA: entries remain.
+	// The blocks keep every listed line, so the totals came from folding them rather than
+	// from an append that dropped the repeat.
 	if want := 3; len(f.Blocks) != want {
 		t.Errorf("got %v\nwant %v", len(f.Blocks), want)
 	}

--- a/coverage/lcov_test.go
+++ b/coverage/lcov_test.go
@@ -215,3 +215,55 @@ end_of_record
 		t.Errorf("got %v\nwant %v", got.Covered, want)
 	}
 }
+
+func TestLcovCountsRepeatedLineInOneRecordOnce(t *testing.T) {
+	// A single record listing the same line twice (e.g. a hand-assembled or
+	// concatenated .info) must count that line once, and a line hit by any of
+	// its DA: entries must read as covered.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lcov.info")
+	content := `TN:
+SF:src/a.ts
+DA:1,1
+DA:1,0
+DA:2,1
+end_of_record
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewLcov().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 1; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	f := got.Files[0]
+	if want := 2; f.Total != want {
+		t.Errorf("got %v\nwant %v", f.Total, want)
+	}
+	if want := 2; f.Covered != want {
+		t.Errorf("got %v\nwant %v", f.Covered, want)
+	}
+	// The blocks are left as read, so all three DA: entries remain.
+	if want := 3; len(f.Blocks) != want {
+		t.Errorf("got %v\nwant %v", len(f.Blocks), want)
+	}
+	if want := 2; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 2; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+	// Exclude() recalculates from blocks; the totals must not change.
+	if err := got.Exclude(nil); err != nil {
+		t.Fatal(err)
+	}
+	if want := 2; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 2; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+}


### PR DESCRIPTION
## Summary

- **A `DA:` line repeated inside a single LCOV record was counted twice.** #725 made the records naming the same file stack and counted their lines once through `ToLineCoverages`, but only from the second record on. The first record of a file kept the plain per-`DA` tally, so `Coverage.Total` came out larger than the number of distinct lines the file has. `SF:./a.ts` with `DA:1,1`, `DA:1,0`, `DA:2,1` in one record returned `total=3` for a file with two lines.
- **This is latent rather than user-visible, the same way #728 was.** `MeasureCoverage` always ends in `Exclude`, whose `reCalc` folds the blocks per line, so every number reaching a comment, a badge or a stored report had already been repaired. What was wrong is the total `ParseReport` hands back, which did not agree with the blocks handed back beside it, and `coverage` is an importable package whose `Processor` is exported.
- **The fold now runs on every record**, which drops the `FindByFile` branch distinction and counts each one the same way. #725 justified the shortcut as leaving an `.info` without repeats parsing exactly as before, and that reason does not require the shortcut. Folding is numerically identical when no line repeats, which is what #731 relied on for the checked-in Cobertura and JaCoCo fixtures. The `total` and `covered` accumulators the shortcut existed for go away with it.
- **The fold happens once after EOF rather than once per record**, in `a5ce67e`. Folding on every `end_of_record` meant a file named by R records had the blocks accumulated so far re-folded R times, so parsing was quadratic in R, and that is exactly the concatenated `.info` #725 added the stacking for. The cost predates this branch, since the fold already ran on the second and later records. Stacking during the scan and folding once per file afterwards is also how SimpleCov, Cobertura and JaCoCo already count. A synthetic `.info` naming one file in R records parses in 1.2ms at R=2500, 2.7ms at R=5000 and 5.3ms at R=10000, against 435ms, 1.79s and 7.59s before. Reports whose files each appear once are unchanged in cost, 281ms against 287ms for 2000 files of 200 lines.
- **Every LOC parser that counts from its blocks now folds them.** SimpleCov, Cobertura and JaCoCo do after #731, `reCalc` always has, and `lcov.go` was the last of those that did not. Clover is not one of them, because it does not count from its blocks at all, taking `Total` and `Covered` from the report's `<metrics>` attributes instead. That is a defect of the same family and is filed separately as #736.

Whether a real writer emits a line twice inside one record is unsettled. `geninfo`, `istanbul` and `llvm-cov` each appear to list a line once per record, so this may be reachable only from a hand-assembled `.info`, or from fragments concatenated without an `end_of_record` between them. Making the parser self-consistent seemed better than depending on that.

The report from the issue is carried as an inline test, written the way the repeated-record test of #725 writes its own, and it fails without the fix. Its block-list assertion carries the wording `a6e918e` gave the Cobertura and JaCoCo ones, so all three say why the pin is there.

Closes #734