### PR TITLE
fix: name a JaCoCo default package file without a leading slash

### DIFF
--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -105,7 +105,15 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 	var order []string
 	for _, p := range r.Package {
 		for _, s := range p.Sourcefile {
-			n := fmt.Sprintf("%s/%s", p.Name, s.Name)
+			// A class in the default package has <package name="">, and joining that with a
+			// separator unconditionally yields "/Foo.java", which filepath.IsAbs reports as
+			// absolute. FuzzyFindByFile gates its package-path branch on !filepath.IsAbs, so
+			// such a name matches neither branch and the file goes missing from the pull
+			// request scope table.
+			n := s.Name
+			if p.Name != "" {
+				n = fmt.Sprintf("%s/%s", p.Name, s.Name)
+			}
 			f, ok := flm[n]
 			if !ok {
 				f = BlockCoverages{}

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -191,3 +191,65 @@ func TestJacocoCountsSharedLineOnce(t *testing.T) {
 		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
 	}
 }
+
+func TestJacocoNamesDefaultPackageFileRelative(t *testing.T) {
+	// A class in the default package has <package name="">. Its file must be named without a
+	// leading slash, so that FuzzyFindByFile, whose package-path branch is gated on
+	// !filepath.IsAbs, can still resolve it from the path it lives at in the repository.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jacocoTestReport.xml")
+	content := `<?xml version="1.0" ?>
+<report name="t">
+  <package name="">
+    <sourcefile name="Foo.java">
+      <line nr="1" mi="0" ci="1"/>
+      <line nr="2" mi="1" ci="0"/>
+    </sourcefile>
+  </package>
+  <package name="com/example">
+    <sourcefile name="Bar.java">
+      <line nr="1" mi="0" ci="1"/>
+    </sourcefile>
+  </package>
+</report>
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewJacoco().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 2; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if want := "Foo.java"; got.Files[0].File != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].File, want)
+	}
+	if want := "com/example/Bar.java"; got.Files[1].File != want {
+		t.Errorf("got %v\nwant %v", got.Files[1].File, want)
+	}
+	for _, f := range got.Files {
+		if filepath.IsAbs(f.File) {
+			t.Errorf("got absolute path %v", f.File)
+		}
+	}
+	// Both files resolve from the path they live at, which is what the pull request scope
+	// table looks them up by.
+	for _, tt := range []struct {
+		file string
+		want string
+	}{
+		{"src/main/java/Foo.java", "Foo.java"},
+		{"src/main/java/com/example/Bar.java", "com/example/Bar.java"},
+	} {
+		f, err := got.Files.FuzzyFindByFile(tt.file)
+		if err != nil {
+			t.Errorf("%s: %v", tt.file, err)
+			continue
+		}
+		if f.File != tt.want {
+			t.Errorf("got %v\nwant %v", f.File, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **A class in the default package went missing from the table of files in pull request scope.** The parser joined the package and the source file with a separator unconditionally, so `<package name="">` yielded `/Foo.java`, which `filepath.IsAbs` reports as absolute on Unix. `FuzzyFindByFile` gates its package-path branch, the one that exists for exactly this shape, on `!filepath.IsAbs`, so it was skipped, and the suffix branch does not match a nested changed path either.
- **`NormalizePaths` covered for it most of the time**, which is why this has not been more visible. It sees the leading slash, fails to make the path relative to the git root, and falls through to a filesystem suffix match that finds the real one. It stops covering when the filesystem index is unavailable, as it is outside a git checkout or when `CollectFiles` fails, and for reports read back from a datastore that were stored without `normalized_path`.
- **The separator is skipped when the package name is empty.** `path.Join` was the other option in the issue and does not compile here, since `ParseReport` takes a parameter named `path` that shadows the package.

## Do not merge as it stands

A self review of this branch found that the fix trades a guaranteed miss for a possible mismatch, inside the very window it targets. Four reviewers reached the same class of problem independently and three of the findings are measured. Recording them here so the branch is not merged on the strength of the summary above.

**The bare basename subverts the shortest-match tie-break.** `FuzzyFindByFile` has kept the shortest candidate since c7aca3b6, whose own tests are entirely about disambiguating same-basename files. A single segment name is the shortest possible candidate, so it wins against a correct longer one.

```
default="/Foo.java"  lookup src/main/java/com/example/Foo.java -> com/example/Foo.java   before, correct
default="Foo.java"   lookup src/main/java/com/example/Foo.java -> Foo.java               after, wrong
```

Slice order does not change it, since the tie-break is by length. A report holding both a default package `Foo.java` and `com/example/Foo.java` reports the wrong file's coverage and patch coverage.

**A nameless `<sourcefile>` becomes a key that matches everything.** With an empty package and no `name` attribute the key is `""`. For `ep == ""` both `!filepath.IsAbs("")` and `strings.HasSuffix(file, "")` are unconditionally true, and length zero beats every legitimate entry, so it can never be displaced. Before the change the key was `/`, which `filepath.IsAbs` rejected, leaving the entry inert. Measured on a report whose two changed lines are both uncovered, `PatchCoverage` goes from `total=2 covered=0` to `total=2 covered=2`, so an `acceptable:` expression referencing `patch` passes regardless of what the changed lines say. `exclude:` cannot suppress it either, since `doublestar.Match` never matches an empty path.

**On Windows the previous code was already correct.** `filepath.IsAbs("/Foo.java")` is false there, so the package-path branch was never gated off and the leading slash acted as a segment anchor. This change removes that anchor, so on Windows it fixes nothing and introduces both problems above. The repo ships Windows builds.

**The suffix comparison is not anchored on a separator**, so `Foo.java` also matches `.../MyFoo.java`. That weakness is pre-existing, since Cobertura already keys on a bare filename, but this change makes it newly reachable from JaCoCo.

Three reviewers converged on the same remedy, which closes all of the above including the Cobertura exposure.

```go
if !filepath.IsAbs(ep) && (file == ep || strings.HasSuffix(file, "/"+ep)) {
```

That widens the change into `coverage/coverage.go`, and the parser separately needs to stop producing an empty key. Smaller notes for the same pass: the code comment states the consequence without the `NormalizePaths` qualification the commit message and the issue both carry, the commit message's "never resolved" is too strong for a file that actually sits at the repository root, the `filepath.IsAbs` claim needs its "on Unix", and the new test uses an inline `range []struct` where the project's testing pattern and all 104 other cases use `tests := []struct`.

Closes #729