### PR TITLE
fix: stop the line and column walks at the top of their range

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -317,7 +317,7 @@ func (fc *FileCoverage) FindBlocksByLine(n int) BlockCoverages {
 			if b.StartLine == nil || b.EndLine == nil {
 				continue
 			}
-			for i := *b.StartLine; i <= *b.EndLine; i++ {
+			for i := range inclusiveRange(*b.StartLine, *b.EndLine) {
 				_, ok := fc.cache[i]
 				if !ok {
 					fc.cache[i] = BlockCoverages{}
@@ -358,12 +358,30 @@ func (dc DiffFileCoverages) FuzzyFindByFile(file string) (*DiffFileCoverage, err
 	return nil, fmt.Errorf("file name not found: %s", file)
 }
 
+// inclusiveRange yields every value from start to end inclusive. It stops at end instead of
+// incrementing past it, so a report naming line or column math.MaxInt does not wrap the
+// counter round to math.MinInt and spin forever while the caller allocates per value. A start
+// above end yields nothing, as the plain loops this replaces did. The line and column walks
+// below were independent copies of the same shape, so a fix in one did not cover the others.
+func inclusiveRange(start, end int) func(func(int) bool) {
+	return func(yield func(int) bool) {
+		for i := start; i <= end; i++ {
+			if !yield(i) {
+				return
+			}
+			if i == end {
+				return
+			}
+		}
+	}
+}
+
 func (bc BlockCoverages) MaxCount() ExecCount { //nostyle:recvtype
 	counts := map[int]ExecCount{}
 	for _, c := range bc {
 		sl := *c.StartLine
 		el := *c.EndLine
-		for i := sl; i <= el; i++ {
+		for i := range inclusiveRange(sl, el) {
 			_, ok := counts[i]
 			if !ok {
 				counts[i] = 0
@@ -462,7 +480,7 @@ func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype
 	for _, c := range bc {
 		sl := *c.StartLine
 		el := *c.EndLine
-		for i := sl; i <= el; i++ {
+		for i := range inclusiveRange(sl, el) {
 			var mm *skipmap.IntMap[ExecCount]
 			mm, ok := m.Load(i)
 			if !ok {
@@ -525,7 +543,7 @@ func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype
 					mm.Store(endPos, *c.Count)
 				}
 			case i == sl && i == el:
-				for j := *c.StartCol; j <= *c.EndCol; j++ {
+				for j := range inclusiveRange(*c.StartCol, *c.EndCol) {
 					v, ok := mm.Load(j)
 					if ok {
 						mm.Store(j, satAdd(v, *c.Count))

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -361,8 +361,9 @@ func (dc DiffFileCoverages) FuzzyFindByFile(file string) (*DiffFileCoverage, err
 // inclusiveRange yields every value from start to end inclusive. It stops at end instead of
 // incrementing past it, so a report naming line or column math.MaxInt does not wrap the
 // counter round to math.MinInt and spin forever while the caller allocates per value. A start
-// above end yields nothing, as the plain loops this replaces did. The line and column walks
-// below were independent copies of the same shape, so a fix in one did not cover the others.
+// above end yields nothing, as the plain loops this replaces did. Its four callers, in
+// FindBlocksByLine, MaxCount and twice in ToLineCoverages, each held an independent copy of
+// the same shape, so a fix in one of them did not cover the others.
 func inclusiveRange(start, end int) func(func(int) bool) {
 	return func(yield func(int) bool) {
 		for i := start; i <= end; i++ {

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -425,4 +426,75 @@ func newBlockCoverage(t Type, sl, sc, el, ec, ns, c int) *BlockCoverage {
 	}
 
 	return bc
+}
+
+func TestLineRangeWalksTerminateAtMaxInt(t *testing.T) {
+	// A line or column number of math.MaxInt used to wrap the loop counter to math.MinInt, so
+	// the walk never ended and ToLineCoverages grew a nested map per key while it spun. Every
+	// walk must instead treat such a block as the single line or column it describes.
+	t.Run("ToLineCoverages", func(t *testing.T) {
+		blocks := BlockCoverages{
+			&BlockCoverage{Type: TypeLOC, StartLine: new(math.MaxInt), EndLine: new(math.MaxInt), Count: new(ExecCount(1))},
+		}
+		lcs := blocks.ToLineCoverages()
+		if want := 1; lcs.Total() != want {
+			t.Errorf("got %v\nwant %v", lcs.Total(), want)
+		}
+		if want := 1; lcs.Covered() != want {
+			t.Errorf("got %v\nwant %v", lcs.Covered(), want)
+		}
+		if want := math.MaxInt; lcs[0].Line != want {
+			t.Errorf("got %v\nwant %v", lcs[0].Line, want)
+		}
+	})
+
+	t.Run("MaxCount", func(t *testing.T) {
+		blocks := BlockCoverages{
+			&BlockCoverage{Type: TypeLOC, StartLine: new(math.MaxInt), EndLine: new(math.MaxInt), Count: new(ExecCount(7))},
+		}
+		if want := ExecCount(7); blocks.MaxCount() != want {
+			t.Errorf("got %v\nwant %v", blocks.MaxCount(), want)
+		}
+	})
+
+	t.Run("FindBlocksByLine", func(t *testing.T) {
+		fc := &FileCoverage{
+			File: "a.kt",
+			Blocks: BlockCoverages{
+				&BlockCoverage{Type: TypeLOC, StartLine: new(math.MaxInt), EndLine: new(math.MaxInt), Count: new(ExecCount(1))},
+			},
+		}
+		if want := 1; len(fc.FindBlocksByLine(math.MaxInt)) != want {
+			t.Errorf("got %v\nwant %v", len(fc.FindBlocksByLine(math.MaxInt)), want)
+		}
+	})
+
+	t.Run("column walk", func(t *testing.T) {
+		// The TypeStmt path walks StartCol to EndCol for a block confined to one line, which
+		// is the fourth copy of the same shape and is not reachable through a line number.
+		blocks := BlockCoverages{
+			&BlockCoverage{
+				Type:      TypeStmt,
+				StartLine: new(1), EndLine: new(1),
+				StartCol: new(math.MaxInt), EndCol: new(math.MaxInt),
+				Count: new(ExecCount(1)),
+			},
+		}
+		lcs := blocks.ToLineCoverages()
+		if want := 1; lcs.Total() != want {
+			t.Errorf("got %v\nwant %v", lcs.Total(), want)
+		}
+	})
+
+	t.Run("start above end yields nothing", func(t *testing.T) {
+		blocks := BlockCoverages{
+			&BlockCoverage{Type: TypeLOC, StartLine: new(5), EndLine: new(3), Count: new(ExecCount(1))},
+		}
+		if want := 0; blocks.ToLineCoverages().Total() != want {
+			t.Errorf("got %v\nwant %v", blocks.ToLineCoverages().Total(), want)
+		}
+		if want := ExecCount(0); blocks.MaxCount() != want {
+			t.Errorf("got %v\nwant %v", blocks.MaxCount(), want)
+		}
+	})
 }

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -431,7 +431,8 @@ func newBlockCoverage(t Type, sl, sc, el, ec, ns, c int) *BlockCoverage {
 func TestLineRangeWalksTerminateAtMaxInt(t *testing.T) {
 	// A line or column number of math.MaxInt used to wrap the loop counter to math.MinInt, so
 	// the walk never ended and ToLineCoverages grew a nested map per key while it spun. Every
-	// walk must instead treat such a block as the single line or column it describes.
+	// walk must instead treat such a block as the single line or column it describes, and a
+	// block whose start is above its end must still yield nothing.
 	t.Run("ToLineCoverages", func(t *testing.T) {
 		blocks := BlockCoverages{
 			&BlockCoverage{Type: TypeLOC, StartLine: new(math.MaxInt), EndLine: new(math.MaxInt), Count: new(ExecCount(1))},


### PR DESCRIPTION
## Summary

- **A line number of `math.MaxInt` made the range walks spin forever.** `BlockCoverages.MaxCount` and `BlockCoverages.ToLineCoverages` walked a block's range with a plain counter, so incrementing past the top wrapped it to `math.MinInt` and the condition stayed true. `ToLineCoverages` stores a nested map per key as it goes, so it grew without bound while it spun. Measured against `main`, a 206 byte Cobertura report hangs `ParseReport` and reaches 3493MB of RSS in ten seconds, so this is a hang plus an out of memory rather than a slow parse.
- **Every format reaches it, and a malformed report should fail rather than spin.** All the LOC parsers fill `StartLine` and `EndLine` from a number the report supplies, and `MeasureCoverage` always ends in `Exclude`, which falls through to `reCalc` and folds through `ToLineCoverages`, so one such line hung the whole run instead of failing it. `Processor` is exported, so a consumer calling `ParseReport` directly was exposed too.
- **Two more copies of the same shape turned up** beside the two the issue names. `FileCoverage.FindBlocksByLine` builds its cache the same way, and the `TypeStmt` path of `ToLineCoverages` walks `StartCol` to `EndCol` for a block confined to one line, which no line number can reach. The issue's own note that a fix in one loop does not cover the other applies to four places, not two.
- **All four now share one iterator that stops at the top of the range** instead of incrementing past it. That is the direction #732 leans towards, and it needs no per-format validation, which matters because the walks are shared by every format. The plain loop could not carry the guard by itself, since the `TypeLOC` branch of `ToLineCoverages` ends in a `continue`, which runs the post statement and would wrap the counter anyway, so the bound has to sit somewhere the body cannot bypass.

Measured on the three reproductions from the issue. Each is a hang reaching gigabytes of RSS before this change and returns in under ten milliseconds after it.

| report | before | after |
| --- | --- | --- |
| Cobertura, 206 B | hang, 3493MB peak RSS | returns, 14MB, `total=1` |
| JaCoCo, 163 B | hang | returns, `total=1` |
| LCOV, 51 B | hang | returns, `total=1` |

Equivalence and cost were both checked rather than argued. Every `start` and `end` pair over -40 to 40 yields the same values, the same count and the same termination as the plain loop, 6561 pairs with no mismatch, and `end == math.MaxInt` is the only input where the two differ. The iterator is inlined at all four call sites with `yield` not escaping, and `allocs/op` is identical, so it costs no allocation. `ToLineCoverages` measures 132ms against 135ms on 200000 blocks and `MaxCount` sits inside run to run spread, both within the noise of an unchanged revision.

## Known gap, filed rather than fixed here

Bounding the counter does not bound the width of a range. A block that merely ends at a huge line still walks it one value at a time, so the walk terminates in principle and not in practice. The five single line formats cannot produce such a block, but Go cover can, and #744 carries the reproduction and the reachability. Two reviewers of this branch raised it independently, so it is worth stating here rather than leaving it to be rediscovered.

`MaxCount` and `ToLineCoverages` also dereference a block's line range without the nil guard that `FindBlocksByLine` carries three functions above. That predates this branch and is #745.

Closes #732