### PR TITLE
fix: count a Clover file named by two elements once

### DIFF
--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -120,20 +120,35 @@ func (c *Clover) ParseReport(path string) (*Coverage, string, error) {
 	cov.Type = TypeLOC
 	cov.Format = c.Name()
 	for _, f := range r.Project.File {
-		fcov := parseReportFile(f)
-		cov.Total += fcov.Total
-		cov.Covered += fcov.Covered
-		cov.Files = append(cov.Files, fcov)
+		mergeReportFile(cov, f)
 	}
 	for _, p := range r.Project.Package {
 		for _, f := range p.File {
-			fcov := parseReportFile(f)
-			cov.Total += fcov.Total
-			cov.Covered += fcov.Covered
-			cov.Files = append(cov.Files, fcov)
+			mergeReportFile(cov, f)
 		}
 	}
+	for _, fcov := range cov.Files {
+		cov.Total += fcov.Total
+		cov.Covered += fcov.Covered
+	}
 	return cov, rp, nil
+}
+
+// mergeReportFile adds one <file> element to cov, stacking it onto the entry already there
+// when the element names a file that has been seen. A report can describe a file at the
+// project level and again inside a <package>, and appending unconditionally listed it twice
+// and counted its statements twice with it.
+func mergeReportFile(cov *Coverage, f CloverReportFile) {
+	fcov := parseReportFile(f)
+	existing, err := cov.Files.FindByFile(fcov.File)
+	if err != nil {
+		cov.Files = append(cov.Files, fcov)
+		return
+	}
+	// Only the blocks stack, the way Coverage.Merge does. The two elements describe the same
+	// file, so their <metrics> say the same thing and the reading already taken stands rather
+	// than being added to.
+	existing.Blocks = append(existing.Blocks, fcov.Blocks...)
 }
 
 func parseReportFile(f CloverReportFile) *FileCoverage {

--- a/coverage/clover_test.go
+++ b/coverage/clover_test.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -115,5 +116,63 @@ func TestCloverParseAllFormat(t *testing.T) {
 		if tt.wantErr != (err != nil) {
 			t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
 		}
+	}
+}
+
+func TestCloverMergesFileNamedTwice(t *testing.T) {
+	// A report describes a file at the project level and again inside a <package>. The file
+	// must be listed once and its statements counted once. The report below describes one
+	// file with 5 statements, of which 4 were executed.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "coverage.xml")
+	content := `<?xml version="1.0" ?>
+<coverage generated="1">
+  <project timestamp="1">
+    <file name="a.php" path="/src/a.php">
+      <metrics statements="5" coveredstatements="4"/>
+      <line num="1" type="stmt" count="1"/>
+    </file>
+    <package name="pkg">
+      <file name="a.php" path="/src/a.php">
+        <metrics statements="5" coveredstatements="4"/>
+        <line num="1" type="stmt" count="1"/>
+      </file>
+    </package>
+  </project>
+</coverage>
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewClover().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 1; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if want := "/src/a.php"; got.Files[0].File != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].File, want)
+	}
+	if want := 5; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 4; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+	if want := 5; got.Files[0].Total != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].Total, want)
+	}
+	if want := 4; got.Files[0].Covered != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].Covered, want)
+	}
+	// The blocks of both elements are kept, so the merge stacked them rather than dropping
+	// the second element outright. Both name line 1, so they fold to the one line the file
+	// enumerates.
+	if want := 2; len(got.Files[0].Blocks) != want {
+		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
+	}
+	if want := 1; got.Files[0].Blocks.ToLineCoverages().Total() != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].Blocks.ToLineCoverages().Total(), want)
 	}
 }


### PR DESCRIPTION
## Summary

- **A file described at the project level and again inside a `<package>` was listed twice and its statements counted twice.** `parseReportFile` was called from a loop over `Project.File` and again from one over `Project.Package[].File`, and each call appended to `Coverage.Files` and added to the running totals. Both entries survive `Exclude`, so the duplicate reached `report.json` and the rendered file list rather than staying inside the parser. This is the shape #724 described for LCOV, which #725 fixed there and this parser kept.
- **The elements now merge through `Files.FindByFile`**, stacking the blocks and summing the file totals after both loops rather than as each element is read.
- **The second half of #733 is left alone, so this closes nothing.** `parseReportFile` still takes `Total` and `Covered` from the `<metrics>` attributes while `Blocks` is built from the `<line type="stmt">` elements. The issue asks for that to be settled deliberately, and #738 covers the `reCalc` override side of it.

One thing the review confirmed in the change's favour, which the original description did not credit. The divergence between the returned total and what its own blocks fold to gets smaller, not larger, because stacked blocks for the same line fold rather than double count. On a fixture with a duplicated file it goes from 59 to 23, and on a duplicate whose line sets are disjoint from 10 to 0. The `Merge` then `reCalc` path was already double counting such a file, and this fixes that too.

## Do not merge as it stands

A self review of this branch found that the merge key is not unique, so the fix silently fuses files that are not the same file. Two reviewers measured it independently, and the rendered percentage changes.

**Two distinct files can be fused, and coverage is overstated.** `parseReportFile` uses a bare basename as the identity whenever `path` is absent and `name` is relative, so two same-named files in different packages collide. `ToLineCoverages` sat-adds per line, so the uncovered lines of one land on the covered lines of the other and vanish.

| | files | final total/covered | rendered |
| --- | --- | --- | --- |
| before | 2 | 4 / 2 | 50.0% |
| after | 1 | 2 / 2 | 100.0% |

Before the change this degraded visibly as a duplicate row and the aggregate was right. After it, it degrades silently and reads high. A crossed or shared `path` attribute produces the same fusion between elements with *different* `name` values, and there the losing file disappears from the file list entirely.

**`current` and `patch` are now derived from disjoint halves of the same file.** The totals come from the surviving element's `<metrics>` while the blocks are the union of both, so one `acceptable:` expression can get a satisfied and a violated variable out of one duplicated file. Measured at 0.00% current against 100.00% patch where before it was 50.00% and 0.00%. This is the block stacking interacting with the deferred half of #733, so it is an argument for settling that half first rather than a defect to patch around.

**Parsing became quadratic.** `FindByFile` is a linear scan run once per `<file>` element, and Clover emits one per file. Measured on synthetic reports of unique files, 10000 files goes from 38ms to 666ms and 80000 from 304ms to 117s. There is an allocation regression alongside it, because the code uses an error-returning lookup as an existence test, so `fmt.Errorf` is built and discarded for every distinct file. `coverage/cobertura.go` and `coverage/jacoco.go` both carry a comment recording this exact cost as the reason they keep a map plus an `order` slice, so the same shape here would remove both problems.

**Which reading wins is decided by traversal order.** The project level loop always runs before the package loop, so a project level element beats a package sibling irrespective of document order. The inline comment asserts the two `<metrics>` "say the same thing" and nothing checks it, and a report merged from parallel test shards legitimately carries two elements with different metrics. This one is not user visible, since every command path reaches `reCalc`, but the comment states an assumption as a fact.

**The `Coverage.Merge` citation is wrong.** `Merge` appends the blocks and then calls `reCalc`, which recomputes the totals from the folded blocks and discards whichever reading was there. It does not keep an earlier reading, so a reader who follows the pointer finds the opposite of what the comment claims. The three sibling parsers cite `Coverage.reCalc` for that reason. Two reviewers raised this independently, and the commit message's "stacking the blocks so a line the second element also lists folds away" overstates it the same way, since the returned totals are untouched by the stacking.

Smaller notes for the same pass: the why-not, that deduplicating on append was rejected, lives only in the commit log where the guidance puts it on the code comment, and the new test's comment does not say that its `Total` of 5 comes from `<metrics>` and does not survive `Exclude`, where the sibling LCOV test pins the opposite guarantee explicitly.

Refs #733