### PR TITLE
fix: skip a block the line walks cannot dereference instead of panicking

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -249,6 +249,22 @@ func (bc *BlockCoverage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// walkable reports whether MaxCount and ToLineCoverages can dereference the block. Every field
+// but Type is omitempty, so a stored report can leave the range, the count or the columns out,
+// and those two walks panicked on such a block while FindBlocksByLine skipped it. They now skip
+// it too, so it contributes no lines rather than being assumed to start at 0. FindBlocksByLine
+// keeps its own narrower check on the range alone, because PatchCoverage reads a block whose
+// count is missing as an uncovered line and needs it returned.
+func (bc *BlockCoverage) walkable() bool {
+	if bc.StartLine == nil || bc.EndLine == nil || bc.Count == nil {
+		return false
+	}
+	if bc.Type != TypeLOC && (bc.StartCol == nil || bc.EndCol == nil) {
+		return false
+	}
+	return true
+}
+
 type BlockCoverages []*BlockCoverage
 
 type Processor interface {
@@ -380,6 +396,9 @@ func inclusiveRange(start, end int) func(func(int) bool) {
 func (bc BlockCoverages) MaxCount() ExecCount { //nostyle:recvtype
 	counts := map[int]ExecCount{}
 	for _, c := range bc {
+		if !c.walkable() {
+			continue
+		}
 		sl := *c.StartLine
 		el := *c.EndLine
 		for i := range inclusiveRange(sl, el) {
@@ -479,6 +498,9 @@ func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype
 	m := skipmap.NewInt[*skipmap.IntMap[ExecCount]]()
 
 	for _, c := range bc {
+		if !c.walkable() {
+			continue
+		}
 		sl := *c.StartLine
 		el := *c.EndLine
 		for i := range inclusiveRange(sl, el) {

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -249,12 +249,13 @@ func (bc *BlockCoverage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// walkable reports whether MaxCount and ToLineCoverages can dereference the block. Every field
-// but Type is omitempty, so a stored report can leave the range, the count or the columns out,
-// and those two walks panicked on such a block while FindBlocksByLine skipped it. They now skip
-// it too, so it contributes no lines rather than being assumed to start at 0. FindBlocksByLine
-// keeps its own narrower check on the range alone, because PatchCoverage reads a block whose
-// count is missing as an uncovered line and needs it returned.
+// walkable reports whether the two line walks, MaxCount and ToLineCoverages, can dereference
+// the block. Every field but Type is omitempty, so a stored report can leave the range, the
+// count or the columns out. Such a block contributes no lines rather than being assumed to
+// start at 0, the reading FindBlocksByLine already had for a missing range. The predicate is
+// the union of what both walks read, so a statement block with no columns is skipped by
+// MaxCount as well, though only ToLineCoverages reads them. FindBlocksByLine does not use it;
+// see the note on its guard.
 func (bc *BlockCoverage) walkable() bool {
 	if bc.StartLine == nil || bc.EndLine == nil || bc.Count == nil {
 		return false
@@ -330,6 +331,8 @@ func (fc *FileCoverage) FindBlocksByLine(n int) BlockCoverages {
 		for _, b := range fc.Blocks {
 			// A stored report can omit the line range, since both fields are omitempty.
 			// Such a block contributes no lines rather than being assumed to start at 0.
+			// Deliberately narrower than walkable, since PatchCoverage reads a block whose
+			// count is missing as an uncovered line and needs it returned.
 			if b.StartLine == nil || b.EndLine == nil {
 				continue
 			}

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -499,3 +499,44 @@ func TestLineRangeWalksTerminateAtMaxInt(t *testing.T) {
 		}
 	})
 }
+
+func TestBlockWalksSkipIncompleteBlocks(t *testing.T) {
+	// Every field of a stored block but its type is omitempty, so a report can come back with
+	// the line range, the columns or the count missing. Each walk must treat such a block as
+	// contributing nothing, the way FindBlocksByLine already did, instead of dereferencing nil.
+	// The complete block beside it must still be counted.
+	complete := &BlockCoverage{Type: TypeLOC, StartLine: new(4), EndLine: new(4), Count: new(ExecCount(2))}
+	tests := []struct {
+		name  string
+		block *BlockCoverage
+	}{
+		{"no line range", &BlockCoverage{Type: TypeLOC, Count: new(ExecCount(1))}},
+		{"no start line", &BlockCoverage{Type: TypeLOC, EndLine: new(1), Count: new(ExecCount(1))}},
+		{"no count", &BlockCoverage{Type: TypeLOC, StartLine: new(1), EndLine: new(1)}},
+		{"statement block without columns", &BlockCoverage{Type: TypeStmt, StartLine: new(1), EndLine: new(1), Count: new(ExecCount(1))}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := BlockCoverages{tt.block, complete}
+			lcs := blocks.ToLineCoverages()
+			if want := 1; lcs.Total() != want {
+				t.Errorf("got %v\nwant %v", lcs.Total(), want)
+			}
+			if want := 4; lcs[0].Line != want {
+				t.Errorf("got %v\nwant %v", lcs[0].Line, want)
+			}
+			if want := ExecCount(2); blocks.MaxCount() != want {
+				t.Errorf("got %v\nwant %v", blocks.MaxCount(), want)
+			}
+		})
+	}
+	// FindBlocksByLine keeps a block whose count is missing, since PatchCoverage reads it as an
+	// uncovered line, and skips only a block with no line range.
+	fc := &FileCoverage{File: "a.go", Blocks: BlockCoverages{
+		&BlockCoverage{Type: TypeLOC, StartLine: new(1), EndLine: new(1)},
+		&BlockCoverage{Type: TypeLOC, Count: new(ExecCount(1))},
+	}}
+	if want := 1; len(fc.FindBlocksByLine(1)) != want {
+		t.Errorf("got %v\nwant %v", len(fc.FindBlocksByLine(1)), want)
+	}
+}

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -503,7 +503,8 @@ func TestLineRangeWalksTerminateAtMaxInt(t *testing.T) {
 func TestBlockWalksSkipIncompleteBlocks(t *testing.T) {
 	// Every field of a stored block but its type is omitempty, so a report can come back with
 	// the line range, the columns or the count missing. Each walk must treat such a block as
-	// contributing nothing, the way FindBlocksByLine already did, instead of dereferencing nil.
+	// contributing nothing, the way FindBlocksByLine already did for a missing range, instead
+	// of dereferencing nil.
 	// The complete block beside it must still be counted.
 	complete := &BlockCoverage{Type: TypeLOC, StartLine: new(4), EndLine: new(4), Count: new(ExecCount(2))}
 	tests := []struct {
@@ -530,13 +531,15 @@ func TestBlockWalksSkipIncompleteBlocks(t *testing.T) {
 			}
 		})
 	}
-	// FindBlocksByLine keeps a block whose count is missing, since PatchCoverage reads it as an
-	// uncovered line, and skips only a block with no line range.
+	// FindBlocksByLine keeps a block whose count or columns are missing, since PatchCoverage
+	// reads a block with no count as an uncovered line, and skips only a block with no line
+	// range.
 	fc := &FileCoverage{File: "a.go", Blocks: BlockCoverages{
 		&BlockCoverage{Type: TypeLOC, StartLine: new(1), EndLine: new(1)},
+		&BlockCoverage{Type: TypeStmt, StartLine: new(1), EndLine: new(1), Count: new(ExecCount(1))},
 		&BlockCoverage{Type: TypeLOC, Count: new(ExecCount(1))},
 	}}
-	if want := 1; len(fc.FindBlocksByLine(1)) != want {
+	if want := 2; len(fc.FindBlocksByLine(1)) != want {
 		t.Errorf("got %v\nwant %v", len(fc.FindBlocksByLine(1)), want)
 	}
 }


### PR DESCRIPTION
## Summary

- **A stored block with its line range omitted panicked two of the three line walks.** Every field of `BlockCoverage` but `Type` is `omitempty`, so a report read back from a datastore can carry a block with no `start_line` and `end_line`. `FindBlocksByLine` guards for that and says why, but `MaxCount` and `ToLineCoverages` dereferenced the same pointers unguarded, so the report that degraded gracefully through one function crashed through the other two.
- **The two walks now share one predicate, `walkable`, covering the union of what they dereference.** That is the range, the count, and for a statement block the columns. It reaches a step past the range #745 names because the count is `omitempty` as well and both walks read it unconditionally. A block that fails it contributes no lines, which is the reading `FindBlocksByLine` already had for a missing range. Since the predicate is a union, `MaxCount` also skips a statement block with no columns even though only `ToLineCoverages` reads them; no parser produces such a block, so this is reachable only from a hand-built stored report.
- **`FindBlocksByLine` deliberately keeps its narrower check, and the reason now sits on the guard.** `PatchCoverage` reads a block whose count is missing as an uncovered line and needs it returned, so the count stays out of that guard. A first draft that shared the predicate there failed `TestFileCoveragePatchCoverage`, though for a different reason than the count. That test's blocks carry no `Type`, so the column clause rejected them all, which is what surfaced the question of whether `FindBlocksByLine` should share the predicate at all. The new test pins the asymmetry so it is not unified by accident later.

The line between this and #744 is drawn on purpose. A block with no range is legitimate output of `omitempty` and is skipped here. A block with an implausibly wide range is malformed input and belongs to #744, which rejects it where the report is read rather than inside the walk.

`reCalc`'s statement branch dereferences `NumStmt` and `Count` the same way and is not touched here, since #745 scoped itself to the two walks. It is filed as its own issue.

Closes #745
