### PR TITLE
fix: reject a block whose range no source file could have

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -190,11 +190,15 @@ func toExecCount(c int) ExecCount {
 	return ExecCount(c)
 }
 
-// maxBlockSpan bounds how many lines, or columns, one block may cover. ToLineCoverages builds a
-// nested map per value it walks, at roughly 600MB per million, so a block wider than this
-// exhausts a CI runner long before the walk finishes, and no coverage tool describes a run of
-// source that long. #741 stopped the walk's counter wrapping at math.MaxInt; a range that merely
-// ends at a huge line still walks it one value at a time, and this is what bounds that.
+// maxBlockSpan bounds the line, or column, a block may reach. ToLineCoverages builds a nested
+// map per value it walks, measured in #744 at roughly 600MB per million, so a file whose blocks
+// reach past this exhausts a CI runner long before the walk finishes, and no source file is a
+// million lines long. Bounding the position rather than the width caps what a file's blocks can
+// walk in total at the constant however many there are, where a width bound let ten blocks
+// placed end to end walk ten times as far. What stays proportional to the input is the number
+// of files, each of which can reach the bound. #741 stopped the walk's counter wrapping at
+// math.MaxInt; a range that merely ends at a huge line still walks it one value at a time, and
+// this is what bounds that.
 const maxBlockSpan = 1_000_000
 
 type BlockCoverage struct {
@@ -259,8 +263,8 @@ func (bc *BlockCoverage) UnmarshalJSON(data []byte) error {
 }
 
 // validateSpan rejects a block whose range cannot describe real source, so the walks never see
-// one. A missing range is legitimate, since the fields are omitempty, and is left to the walks
-// to skip rather than rejected here.
+// one. A missing range is not rejected, since the fields are omitempty and a stored report can
+// legitimately leave them out; what the walks do with one is #745's concern.
 func (bc *BlockCoverage) validateSpan() error {
 	if err := checkSpan(bc.StartLine, bc.EndLine, "line"); err != nil {
 		return err
@@ -274,8 +278,8 @@ func (bc *BlockCoverage) validateSpan() error {
 	return checkSpan(bc.StartCol, bc.EndCol, "column")
 }
 
-// checkSpan orders its tests so the subtraction cannot overflow. Once start is non-negative and
-// end is not below it, end minus start lies within int.
+// checkSpan rejects a negative start, an end below the start, and an end past maxBlockSpan. With
+// the start at zero or more and the end no further than the constant, the width is bounded too.
 func checkSpan(start, end *int, what string) error {
 	if start == nil || end == nil {
 		return nil
@@ -285,8 +289,8 @@ func checkSpan(start, end *int, what string) error {
 		return fmt.Errorf("negative %s number: %d", what, *start)
 	case *end < *start:
 		return fmt.Errorf("block ends before it starts: %s %d..%d", what, *start, *end)
-	case *end-*start > maxBlockSpan:
-		return fmt.Errorf("block spans %d %ss, more than the %d octocov accepts", *end-*start, what, maxBlockSpan)
+	case *end > maxBlockSpan:
+		return fmt.Errorf("block reaches %s %d, past the %d octocov accepts", what, *end, maxBlockSpan)
 	}
 	return nil
 }

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -190,6 +190,13 @@ func toExecCount(c int) ExecCount {
 	return ExecCount(c)
 }
 
+// maxBlockSpan bounds how many lines, or columns, one block may cover. ToLineCoverages builds a
+// nested map per value it walks, at roughly 600MB per million, so a block wider than this
+// exhausts a CI runner long before the walk finishes, and no coverage tool describes a run of
+// source that long. #741 stopped the walk's counter wrapping at math.MaxInt; a range that merely
+// ends at a huge line still walks it one value at a time, and this is what bounds that.
+const maxBlockSpan = 1_000_000
+
 type BlockCoverage struct {
 	Type      Type       `json:"type"`
 	StartLine *int       `json:"start_line,omitempty"`
@@ -245,6 +252,41 @@ func (bc *BlockCoverage) UnmarshalJSON(data []byte) error {
 	if a.CountU64 != nil {
 		c := ExecCount(*a.CountU64)
 		bc.Count = &c
+	}
+	// Every path that reads a stored report, whether a local file, a datastore, BigQuery or the
+	// central index, comes through here, so this is the one place a stored block is checked.
+	return bc.validateSpan()
+}
+
+// validateSpan rejects a block whose range cannot describe real source, so the walks never see
+// one. A missing range is legitimate, since the fields are omitempty, and is left to the walks
+// to skip rather than rejected here.
+func (bc *BlockCoverage) validateSpan() error {
+	if err := checkSpan(bc.StartLine, bc.EndLine, "line"); err != nil {
+		return err
+	}
+	// The columns of a block that spans lines sit on different lines, so the end column is
+	// routinely below the start column and their distance means nothing. Only the walk over a
+	// single line's columns can run away, so only that shape has its columns checked.
+	if bc.StartLine == nil || bc.EndLine == nil || *bc.StartLine != *bc.EndLine {
+		return nil
+	}
+	return checkSpan(bc.StartCol, bc.EndCol, "column")
+}
+
+// checkSpan orders its tests so the subtraction cannot overflow. Once start is non-negative and
+// end is not below it, end minus start lies within int.
+func checkSpan(start, end *int, what string) error {
+	if start == nil || end == nil {
+		return nil
+	}
+	switch {
+	case *start < 0:
+		return fmt.Errorf("negative %s number: %d", what, *start)
+	case *end < *start:
+		return fmt.Errorf("block ends before it starts: %s %d..%d", what, *start, *end)
+	case *end-*start > maxBlockSpan:
+		return fmt.Errorf("block spans %d %ss, more than the %d octocov accepts", *end-*start, what, maxBlockSpan)
 	}
 	return nil
 }

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -541,5 +542,36 @@ func TestBlockWalksSkipIncompleteBlocks(t *testing.T) {
 	}}
 	if want := 2; len(fc.FindBlocksByLine(1)) != want {
 		t.Errorf("got %v\nwant %v", len(fc.FindBlocksByLine(1)), want)
+	}
+}
+
+func TestBlockCoverageRejectsImplausibleSpan(t *testing.T) {
+	// A stored report is the one ingestion path every parser shares, so a block whose range
+	// cannot describe real source must fail to load rather than reach a walk that allocates per
+	// line. A missing range stays legitimate, since the fields are omitempty.
+	tests := []struct {
+		name    string
+		json    string
+		wantErr bool
+	}{
+		{"one line", `{"type":"loc","start_line":3,"end_line":3,"count":1}`, false},
+		{"widest span accepted", `{"type":"stmt","start_line":1,"end_line":1000001,"start_col":1,"end_col":1,"count":1}`, false},
+		{"no range", `{"type":"loc","count":1}`, false},
+		{"ends before it starts", `{"type":"loc","start_line":5,"end_line":3,"count":1}`, true},
+		{"negative line", `{"type":"loc","start_line":-1,"end_line":1,"count":1}`, true},
+		{"wide line span", `{"type":"stmt","start_line":1,"end_line":9223372036854775806,"start_col":1,"end_col":1,"count":1}`, true},
+		{"wide column span", `{"type":"stmt","start_line":1,"end_line":1,"start_col":1,"end_col":9223372036854775806,"count":1}`, true},
+		// A block spanning lines ends at a column below the one it started at, as in a stored Go
+		// cover report, and that is not an inverted range.
+		{"end column below start column across lines", `{"type":"stmt","start_line":10,"end_line":12,"start_col":66,"end_col":25,"count":1}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b BlockCoverage
+			err := json.Unmarshal([]byte(tt.json), &b)
+			if tt.wantErr != (err != nil) {
+				t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -555,7 +555,11 @@ func TestBlockCoverageRejectsImplausibleSpan(t *testing.T) {
 		wantErr bool
 	}{
 		{"one line", `{"type":"loc","start_line":3,"end_line":3,"count":1}`, false},
-		{"widest span accepted", `{"type":"stmt","start_line":1,"end_line":1000001,"start_col":1,"end_col":1,"count":1}`, false},
+		{"furthest line accepted", `{"type":"stmt","start_line":1,"end_line":1000000,"start_col":1,"end_col":1,"count":1}`, false},
+		{"one line past it", `{"type":"stmt","start_line":1,"end_line":1000001,"start_col":1,"end_col":1,"count":1}`, true},
+		// The bound is on where a block ends, not how wide it is, so narrow blocks placed far
+		// out are rejected too.
+		{"narrow block past the bound", `{"type":"loc","start_line":1000005,"end_line":1000006,"count":1}`, true},
 		{"no range", `{"type":"loc","count":1}`, false},
 		{"ends before it starts", `{"type":"loc","start_line":5,"end_line":3,"count":1}`, true},
 		{"negative line", `{"type":"loc","start_line":-1,"end_line":1,"count":1}`, true},

--- a/coverage/gocover.go
+++ b/coverage/gocover.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -45,7 +46,7 @@ func (g *Gocover) ParseReport(path string) (*Coverage, string, error) {
 			ec := b.EndCol
 			ns := b.NumStmt
 			c := toExecCount(b.Count)
-			fcov.Blocks = append(fcov.Blocks, &BlockCoverage{
+			blk := &BlockCoverage{
 				Type:      TypeStmt,
 				StartLine: &sl,
 				StartCol:  &sc,
@@ -53,7 +54,14 @@ func (g *Gocover) ParseReport(path string) (*Coverage, string, error) {
 				EndCol:    &ec,
 				NumStmt:   &ns,
 				Count:     &c,
-			})
+			}
+			// x/tools/cover accepts any integer here, and this is the one format whose blocks
+			// span lines, since the others set StartLine equal to EndLine. So it is the one
+			// parser that can hand the walks a range no source file has.
+			if err := blk.validateSpan(); err != nil {
+				return nil, "", fmt.Errorf("%s: %w", rp, err)
+			}
+			fcov.Blocks = append(fcov.Blocks, blk)
 		}
 		cov.Total += total
 		cov.Covered += covered

--- a/coverage/gocover.go
+++ b/coverage/gocover.go
@@ -55,11 +55,11 @@ func (g *Gocover) ParseReport(path string) (*Coverage, string, error) {
 				NumStmt:   &ns,
 				Count:     &c,
 			}
-			// x/tools/cover accepts any integer here, and this is the one format whose blocks
-			// span lines, since the others set StartLine equal to EndLine. So it is the one
-			// parser that can hand the walks a range no source file has.
+			// x/tools/cover rejects nothing here but a negative position, and this is the one
+			// format whose blocks span lines, since the others set StartLine equal to EndLine.
+			// So it is the one parser that can hand the walks a range no source file has.
 			if err := blk.validateSpan(); err != nil {
-				return nil, "", fmt.Errorf("%s: %w", rp, err)
+				return nil, "", fmt.Errorf("%s: %s: %w", rp, p.FileName, err)
 			}
 			fcov.Blocks = append(fcov.Blocks, blk)
 		}

--- a/coverage/gocover_test.go
+++ b/coverage/gocover_test.go
@@ -86,6 +86,8 @@ func TestGocoverRejectsImplausibleBlock(t *testing.T) {
 		{"wide line span", "x.go:1.1,9223372036854775806.1 1 1", true},
 		{"wide column span", "x.go:1.1,1.9223372036854775806 1 1", true},
 		{"ends before it starts", "x.go:9.1,3.1 1 1", true},
+		{"furthest line accepted", "x.go:1.1,1000000.1 1 1", false},
+		{"narrow block past the bound", "x.go:1000001.1,1000002.1 1 1", true},
 		// The usual shape of a block that spans lines, ending at a column below where it began.
 		{"spans lines", "x.go:10.66,12.25 1 1", false},
 	}

--- a/coverage/gocover_test.go
+++ b/coverage/gocover_test.go
@@ -73,3 +73,33 @@ func testdataDir(t *testing.T) string {
 	}
 	return dir
 }
+
+func TestGocoverRejectsImplausibleBlock(t *testing.T) {
+	// x/tools/cover accepts any integer for a block's lines and columns, and Go cover is the one
+	// format whose blocks span lines, so a profile can describe a run of source no file has. The
+	// parse must fail rather than hand the block to a walk that allocates per line.
+	tests := []struct {
+		name    string
+		block   string
+		wantErr bool
+	}{
+		{"wide line span", "x.go:1.1,9223372036854775806.1 1 1", true},
+		{"wide column span", "x.go:1.1,1.9223372036854775806 1 1", true},
+		{"ends before it starts", "x.go:9.1,3.1 1 1", true},
+		// The usual shape of a block that spans lines, ending at a column below where it began.
+		{"spans lines", "x.go:10.66,12.25 1 1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "coverage.out")
+			if err := os.WriteFile(path, []byte("mode: count\n"+tt.block+"\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, _, err := NewGocover().ParseReport(path)
+			if tt.wantErr != (err != nil) {
+				t.Errorf("got %v\nwantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/report/load_test.go
+++ b/report/load_test.go
@@ -1,0 +1,45 @@
+package report
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/k1LoW/octocov/coverage"
+)
+
+func TestLoadNamesTheReportItRejects(t *testing.T) {
+	// BlockCoverage.UnmarshalJSON rejects a block whose range no source file could have, and it
+	// cannot know which report it is decoding, so the error must carry the path.
+	r := &Report{Coverage: &coverage.Coverage{
+		Type: coverage.TypeStmt,
+		Files: coverage.FileCoverages{
+			&coverage.FileCoverage{File: "x.go", Type: coverage.TypeStmt, Blocks: coverage.BlockCoverages{
+				&coverage.BlockCoverage{Type: coverage.TypeStmt, StartLine: new(5), StartCol: new(1), EndLine: new(7), EndCol: new(1), NumStmt: new(1), Count: new(coverage.ExecCount(1))},
+			}},
+		},
+	}}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Replace(string(b), `"end_line":7`, `"end_line":9223372036854775806`, 1)
+	if content == string(b) {
+		t.Fatal("fixture did not take")
+	}
+	path := filepath.Join(t.TempDir(), "report.json")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err = (&Report{}).Load(path)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	for _, want := range []string{path, "block reaches line"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+}

--- a/report/report.go
+++ b/report/report.go
@@ -417,8 +417,10 @@ func (r *Report) Load(path string) error {
 	if err != nil {
 		return err
 	}
+	// BlockCoverage.UnmarshalJSON can reject a block and knows nothing about which report it
+	// is decoding, and a datastore holds many, so the path goes on the error here.
 	if err := json.Unmarshal(b, r); err != nil {
-		return err
+		return fmt.Errorf("%s: %w", path, err)
 	}
 	r.covPaths = append(r.covPaths, path)
 	return nil


### PR DESCRIPTION
## Summary

- **Bounding the counter did not bound the range.** #741 stopped the walks wrapping at `math.MaxInt`, but a block that merely ends at a huge line still walks it one value at a time while `ToLineCoverages` builds a nested map per line, at roughly 600MB per million. A 47 byte Go cover profile, `x.go:1.1,9223372036854775806.1 1 1`, still hung `FindBlocksByLine` and `MaxCount` and drove a runner to OOM, and `EndLine = 20000000` was already enough. `FindBlocksByLine` sits on the default pull request path through `FileCoveragesTable`, so it needed no configuration to reach.
- **A block is rejected where it enters, by where it ends.** Go cover is the one format whose blocks span lines, since the other five set `StartLine` equal to `EndLine`, so its parser validates each block as it is built. Every path that reads a stored report unmarshals through `BlockCoverage.UnmarshalJSON`, so a stored block is checked there. The bound is `maxBlockSpan = 1_000_000` on the line, or column, a block may reach. The first cut bounded the width instead, and the self-review found that ten blocks of a million lines placed end to end, a few hundred bytes of profile, still walked ten million lines. Bounding the position caps what a file's blocks walk in total however many there are; what stays proportional to the input is the number of files, and that costs the writer a line of profile per file rather than a byte per line. The consequence is that a source file longer than a million lines fails the parse. That is accepted; no real file is that long, and a runner going out of memory on a few hundred bytes of profile is the worse outcome.
- **An inverted range is rejected as well.** #741 recorded that a start above its end "still yields nothing, which is what the plain loops did", which was about preserving behaviour, not endorsing the shape. Neither #744 nor its reproduction asks for this. It is included because such a block is corrupt in the same way, and is called out here so it is a decision rather than a side effect.
- **The rejection names what it rejected.** `BlockCoverage.UnmarshalJSON` knows neither the report nor the file, so `report.Load` puts the path on the error and the Go cover parser puts the profile path and the file. Whether a rejected report is fatal depends on the reader, as it always has for a decode error. `report.Load` fails, the previous-report loop in `cmd/root.go` logs and skips it, and central mode skips it silently. A corrupt report in a datastore therefore costs the comparison or the index entry, not the run.
- **A first draft rejected a real stored report.** `testdata/reports/k1LoW/tbls/report.json` carries a Go cover block spanning lines whose end column, 25, is below its start column, 66, because the two columns sit on different lines. That is the normal shape of a multi-line block, so the column check applies only to a block confined to one line, which is also the only shape whose column walk in `ToLineCoverages` can run away. `TestCollectReports` caught it and the shape is pinned in both tests.

Columns of a multi-line block are not checked for sign either, since the walk never iterates them; `x/tools/cover` rejects negative positions itself, so that can only come from a hand-written stored report and is harmless there.

A missing range is left alone. It is legitimate output of `omitempty`, and #746 makes the walks skip it, which is the other half of the line drawn between #744 and #745.

Closes #744
