### PR TITLE
fix: anchor the fuzzy file match on a path segment and prefer the more specific candidate

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -294,29 +294,34 @@ func (fc FileCoverages) FuzzyFindByFile(file string) (*FileCoverage, error) { //
 // with it (a report recording package paths, ex. org/repo/package/path/to/Target.kt). Either
 // way the match has to end at a path segment, since a bare strings.HasSuffix let domain.go stand
 // in for main.go and a bare Foo.java for MyFoo.java, and made an entry with no name a suffix of
-// everything.
+// everything. A leading ./ on either side is ignored and nothing else is, so a dotfile keeps its
+// dot.
 //
-// Among the matches the one sharing the longest portion of the file wins, and on a tie the one
-// with fewer unmatched segments. The shortest candidate used to win outright, which is the right
-// call when candidates are absolute paths all ending in the file, but the wrong one when they
-// are package paths the file ends in, where com/example/Foo.java is more specific than Foo.java
-// and yet shorter candidates always won.
+// Among the matches the one sharing the longest portion of the file wins, on a tie the shorter
+// candidate, and between candidates of equal length the first listed. The shortest candidate
+// used to win outright, which is the right call when candidates are absolute paths all ending
+// in the file, but the wrong one when they are package paths the file ends in, where
+// com/example/Foo.java is more specific than Foo.java and yet shorter candidates always won.
 func fuzzyMatch(file string, n int, path func(int) string) int {
-	f := strings.TrimLeft(file, "./")
+	f := trimDotSlash(file)
 	if f == "" {
 		return -1
 	}
+	sf := "/" + f
 	best, bestShared, bestLen := -1, 0, 0
 	for i := range n {
 		p := path(i)
-		e := strings.TrimLeft(p, "./")
+		e := trimDotSlash(p)
+		if e == "" {
+			continue
+		}
 		var shared int
 		switch {
 		case e == f:
 			shared = len(f)
-		case strings.HasSuffix(e, "/"+f):
+		case strings.HasSuffix(e, sf):
 			shared = len(f)
-		case !filepath.IsAbs(p) && strings.HasSuffix(f, "/"+e):
+		case !filepath.IsAbs(p) && len(f) > len(e) && f[len(f)-len(e)-1] == '/' && strings.HasSuffix(f, e):
 			shared = len(e)
 		default:
 			continue
@@ -326,6 +331,17 @@ func fuzzyMatch(file string, n int, path func(int) string) int {
 		}
 	}
 	return best
+}
+
+// trimDotSlash strips a leading "./" as often as it appears and nothing else. strings.TrimLeft
+// with the cutset "./" also stripped the dot of a dotfile or a dot directory, which a bare suffix
+// match tolerated and a match anchored on a separator did not, since ".eslintrc.js" then had to
+// end in "/eslintrc.js".
+func trimDotSlash(p string) string {
+	for strings.HasPrefix(p, "./") {
+		p = p[2:]
+	}
+	return p
 }
 
 func (fc *FileCoverage) FindBlocksByLine(n int) BlockCoverages {

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -281,28 +281,51 @@ func (fc FileCoverages) FindByFile(file string) (*FileCoverage, error) { //nosty
 }
 
 func (fc FileCoverages) FuzzyFindByFile(file string) (*FileCoverage, error) { //nostyle:recvtype
-	var match *FileCoverage
-	for _, c := range fc {
-		ep := c.EffectivePath()
-		// When coverages are recorded with absolute path. ( ex. /path/to/owner/repo/target.go
-		if strings.HasSuffix(strings.TrimLeft(ep, "./"), strings.TrimLeft(file, "./")) {
-			if match == nil || len(match.EffectivePath()) > len(ep) {
-				match = c
-			}
+	i := fuzzyMatch(file, len(fc), func(i int) string { return fc[i].EffectivePath() })
+	if i < 0 {
+		return nil, fmt.Errorf("file name not found: %s", file)
+	}
+	return fc[i], nil
+}
+
+// fuzzyMatch picks, among n candidate paths, the one that best resolves a changed file, and
+// returns its index or -1. A candidate matches when it is the file, when it ends with the file
+// (a report recording absolute paths, ex. /path/to/owner/repo/target.go), or when the file ends
+// with it (a report recording package paths, ex. org/repo/package/path/to/Target.kt). Either
+// way the match has to end at a path segment, since a bare strings.HasSuffix let domain.go stand
+// in for main.go and a bare Foo.java for MyFoo.java, and made an entry with no name a suffix of
+// everything.
+//
+// Among the matches the one sharing the longest portion of the file wins, and on a tie the one
+// with fewer unmatched segments. The shortest candidate used to win outright, which is the right
+// call when candidates are absolute paths all ending in the file, but the wrong one when they
+// are package paths the file ends in, where com/example/Foo.java is more specific than Foo.java
+// and yet shorter candidates always won.
+func fuzzyMatch(file string, n int, path func(int) string) int {
+	f := strings.TrimLeft(file, "./")
+	if f == "" {
+		return -1
+	}
+	best, bestShared, bestLen := -1, 0, 0
+	for i := range n {
+		p := path(i)
+		e := strings.TrimLeft(p, "./")
+		var shared int
+		switch {
+		case e == f:
+			shared = len(f)
+		case strings.HasSuffix(e, "/"+f):
+			shared = len(f)
+		case !filepath.IsAbs(p) && strings.HasSuffix(f, "/"+e):
+			shared = len(e)
+		default:
 			continue
 		}
-		// When coverages are recorded in the package path. ( ex. org/repo/package/path/to/Target.kt
-		if !filepath.IsAbs(ep) && strings.HasSuffix(file, ep) {
-			if match == nil || len(match.EffectivePath()) > len(ep) {
-				match = c
-			}
-			continue
+		if best < 0 || shared > bestShared || (shared == bestShared && len(e) < bestLen) {
+			best, bestShared, bestLen = i, shared, len(e)
 		}
 	}
-	if match != nil {
-		return match, nil
-	}
-	return nil, fmt.Errorf("file name not found: %s", file)
+	return best
 }
 
 func (fc *FileCoverage) FindBlocksByLine(n int) BlockCoverages {
@@ -335,27 +358,11 @@ func (fc *FileCoverage) FindBlocksByLine(n int) BlockCoverages {
 }
 
 func (dc DiffFileCoverages) FuzzyFindByFile(file string) (*DiffFileCoverage, error) { //nostyle:recvtype
-	var match *DiffFileCoverage
-	for _, c := range dc {
-		// When coverages are recorded with absolute path. ( ex. /path/to/owner/repo/target.go
-		if strings.HasSuffix(strings.TrimLeft(c.File, "./"), strings.TrimLeft(file, "./")) {
-			if match == nil || len(match.File) > len(c.File) {
-				match = c
-			}
-			continue
-		}
-		// When coverages are recorded in the package path. ( ex. org/repo/package/path/to/Target.kt
-		if !filepath.IsAbs(c.File) && strings.HasSuffix(file, c.File) {
-			if match == nil || len(match.File) > len(c.File) {
-				match = c
-			}
-			continue
-		}
+	i := fuzzyMatch(file, len(dc), func(i int) string { return dc[i].File })
+	if i < 0 {
+		return nil, fmt.Errorf("file name not found: %s", file)
 	}
-	if match != nil {
-		return match, nil
-	}
-	return nil, fmt.Errorf("file name not found: %s", file)
+	return dc[i], nil
 }
 
 // inclusiveRange yields every value from start to end inclusive. It stops at end instead of

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -302,6 +302,20 @@ func TestFuzzyFindByFile(t *testing.T) {
 			"/path/to/owner/repo/target.go",
 			false,
 		},
+		// The whole path outranks any suffix of it.
+		{[]string{"a/target.go", "src/a/target.go"}, "src/a/target.go", "src/a/target.go", false},
+		// A package path outranks a bare filename for a lookup that contains both, since it
+		// shares more of the path, whichever order the report lists them in. A JaCoCo default
+		// package produces the bare filename.
+		{[]string{"Foo.java", "com/example/Foo.java"}, "src/main/java/com/example/Foo.java", "com/example/Foo.java", false},
+		{[]string{"com/example/Foo.java", "Foo.java"}, "src/main/java/com/example/Foo.java", "com/example/Foo.java", false},
+		{[]string{"Foo.java", "com/example/Foo.java"}, "src/main/java/Foo.java", "Foo.java", false},
+		// A match has to end at a path segment, in either direction.
+		{[]string{"Foo.java"}, "src/main/java/MyFoo.java", "", true},
+		{[]string{"/path/to/repo/domain.go"}, "main.go", "", true},
+		// An entry with no name is a suffix of nothing rather than of everything.
+		{[]string{"", "src/a/target.go"}, "src/a/target.go", "src/a/target.go", false},
+		{[]string{""}, "src/a/target.go", "", true},
 	}
 	for _, tt := range tests {
 		fcs := FileCoverages{}

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -309,13 +309,24 @@ func TestFuzzyFindByFile(t *testing.T) {
 		// package produces the bare filename.
 		{[]string{"Foo.java", "com/example/Foo.java"}, "src/main/java/com/example/Foo.java", "com/example/Foo.java", false},
 		{[]string{"com/example/Foo.java", "Foo.java"}, "src/main/java/com/example/Foo.java", "com/example/Foo.java", false},
+		// The bare filename still resolves from its own path, which the package path does not
+		// match.
 		{[]string{"Foo.java", "com/example/Foo.java"}, "src/main/java/Foo.java", "Foo.java", false},
 		// A match has to end at a path segment, in either direction.
 		{[]string{"Foo.java"}, "src/main/java/MyFoo.java", "", true},
 		{[]string{"/path/to/repo/domain.go"}, "main.go", "", true},
-		// An entry with no name is a suffix of nothing rather than of everything.
+		// An entry with no name is a suffix of nothing rather than of everything, even of a
+		// lookup that ends in a separator.
 		{[]string{"", "src/a/target.go"}, "src/a/target.go", "src/a/target.go", false},
 		{[]string{""}, "src/a/target.go", "", true},
+		{[]string{""}, "a/", "", true},
+		// A leading ./ is ignored on either side and nothing else is, so a dotfile keeps its dot
+		// and resolves from an absolute or a nested path, and a dot directory is not the
+		// directory without the dot.
+		{[]string{"/home/runner/work/repo/repo/.eslintrc.js"}, ".eslintrc.js", "/home/runner/work/repo/repo/.eslintrc.js", false},
+		{[]string{".storybook/preview.ts"}, "frontend/.storybook/preview.ts", ".storybook/preview.ts", false},
+		{[]string{"./lib/x.rb"}, "src/lib/x.rb", "./lib/x.rb", false},
+		{[]string{".config/x.go"}, "src/config/x.go", "", true},
 	}
 	for _, tt := range tests {
 		fcs := FileCoverages{}

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -105,18 +105,21 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 	var order []string
 	for _, p := range r.Package {
 		for _, s := range p.Sourcefile {
+			// A <sourcefile> with no name would key an entry on "" or on "pkg/", and no changed
+			// path ends in either, so the entry could resolve nothing and would only clutter the
+			// file list.
+			if s.Name == "" {
+				continue
+			}
 			// A class in the default package has <package name="">, and joining that with a
 			// separator unconditionally yields "/Foo.java", which filepath.IsAbs reports as
-			// absolute on Unix. FuzzyFindByFile then refuses to read it as a package path, so
-			// the file never resolves against the pull request's changed files.
+			// absolute on Unix. FuzzyFindByFile then refuses to read it as a package path, so a
+			// changed path nested below the repository root never resolved to it unless
+			// NormalizePaths had already rewritten it from the filesystem index. path.Join would
+			// handle the empty package, but ParseReport's parameter is named path and shadows it.
 			n := s.Name
 			if p.Name != "" {
 				n = fmt.Sprintf("%s/%s", p.Name, s.Name)
-			}
-			// A <sourcefile> with no name would key an entry on "", which resolves nothing
-			// and only clutters the file list, so none is made.
-			if n == "" {
-				continue
 			}
 			f, ok := flm[n]
 			if !ok {

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -105,7 +105,19 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 	var order []string
 	for _, p := range r.Package {
 		for _, s := range p.Sourcefile {
-			n := fmt.Sprintf("%s/%s", p.Name, s.Name)
+			// A class in the default package has <package name="">, and joining that with a
+			// separator unconditionally yields "/Foo.java", which filepath.IsAbs reports as
+			// absolute on Unix. FuzzyFindByFile then refuses to read it as a package path, so
+			// the file never resolves against the pull request's changed files.
+			n := s.Name
+			if p.Name != "" {
+				n = fmt.Sprintf("%s/%s", p.Name, s.Name)
+			}
+			// A <sourcefile> with no name would key an entry on "", which resolves nothing
+			// and only clutters the file list, so none is made.
+			if n == "" {
+				continue
+			}
 			f, ok := flm[n]
 			if !ok {
 				f = BlockCoverages{}

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -257,9 +257,9 @@ func TestJacocoNamesDefaultPackageFileRelative(t *testing.T) {
 }
 
 func TestJacocoSkipsSourcefileWithoutName(t *testing.T) {
-	// A <sourcefile> with no name in the default package would key an entry on "". Such an
-	// entry resolves nothing and only clutters the file list, so none is made and the named
-	// file beside it is unaffected.
+	// A <sourcefile> with no name would key an entry on "" in the default package and on
+	// "pkg/" in a named one. Neither can resolve a changed path, so none is made and the named
+	// file beside them is unaffected.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "jacocoTestReport.xml")
 	content := `<?xml version="1.0" ?>
@@ -270,6 +270,11 @@ func TestJacocoSkipsSourcefileWithoutName(t *testing.T) {
     </sourcefile>
     <sourcefile name="Foo.java">
       <line nr="1" mi="1" ci="0"/>
+    </sourcefile>
+  </package>
+  <package name="com/example">
+    <sourcefile>
+      <line nr="1" mi="0" ci="1"/>
     </sourcefile>
   </package>
 </report>

--- a/coverage/jacoco_test.go
+++ b/coverage/jacoco_test.go
@@ -191,3 +191,103 @@ func TestJacocoCountsSharedLineOnce(t *testing.T) {
 		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
 	}
 }
+
+func TestJacocoNamesDefaultPackageFileRelative(t *testing.T) {
+	// A class in the default package has <package name="">. Its file must be named without a
+	// leading slash, so that FuzzyFindByFile can resolve it from the path it lives at in the
+	// repository, which is the lookup the pull request scope table performs.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jacocoTestReport.xml")
+	content := `<?xml version="1.0" ?>
+<report name="t">
+  <package name="">
+    <sourcefile name="Foo.java">
+      <line nr="1" mi="0" ci="1"/>
+      <line nr="2" mi="1" ci="0"/>
+    </sourcefile>
+  </package>
+  <package name="com/example">
+    <sourcefile name="Bar.java">
+      <line nr="1" mi="0" ci="1"/>
+    </sourcefile>
+    <sourcefile name="Foo.java">
+      <line nr="1" mi="0" ci="1"/>
+    </sourcefile>
+  </package>
+</report>
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewJacoco().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 3; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if want := "Foo.java"; got.Files[0].File != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].File, want)
+	}
+	for _, f := range got.Files {
+		if filepath.IsAbs(f.File) {
+			t.Errorf("got absolute path %v", f.File)
+		}
+	}
+	// Each file resolves from the path it lives at, and the same basename in the default
+	// package and in a named package go to their own files.
+	tests := []struct {
+		file string
+		want string
+	}{
+		{"src/main/java/Foo.java", "Foo.java"},
+		{"src/main/java/com/example/Bar.java", "com/example/Bar.java"},
+		{"src/main/java/com/example/Foo.java", "com/example/Foo.java"},
+	}
+	for _, tt := range tests {
+		f, err := got.Files.FuzzyFindByFile(tt.file)
+		if err != nil {
+			t.Errorf("%s: %v", tt.file, err)
+			continue
+		}
+		if f.File != tt.want {
+			t.Errorf("got %v\nwant %v", f.File, tt.want)
+		}
+	}
+}
+
+func TestJacocoSkipsSourcefileWithoutName(t *testing.T) {
+	// A <sourcefile> with no name in the default package would key an entry on "". Such an
+	// entry resolves nothing and only clutters the file list, so none is made and the named
+	// file beside it is unaffected.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jacocoTestReport.xml")
+	content := `<?xml version="1.0" ?>
+<report name="t">
+  <package name="">
+    <sourcefile>
+      <line nr="1" mi="0" ci="1"/>
+    </sourcefile>
+    <sourcefile name="Foo.java">
+      <line nr="1" mi="1" ci="0"/>
+    </sourcefile>
+  </package>
+</report>
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewJacoco().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := 1; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if want := "Foo.java"; got.Files[0].File != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].File, want)
+	}
+	if want := 0; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+}


### PR DESCRIPTION
## Summary

- **`FuzzyFindByFile` matched on a bare suffix in both directions and kept the shortest candidate, and on the repo's own Cobertura fixture that resolves 69 of 305 files to the wrong entry today.** Looked up by its own path, `test_datastructures.py` resolves to `datastructures.py`, `dependencies/__init__.py` to `__init__.py`, and `test_modules_same_name_body/app/main.py` to `main.py`. An exact match loses to any shorter entry whose name happens to end the path, because nothing required the match to end at a path segment and the tie-break preferred length alone. The stored `testdata/reports/tiangolo/fastapi/report.json` shows the same 69 misattributions. After this change every entry in every fixture and every stored report resolves to itself.
- **The two `FuzzyFindByFile` methods now share one matcher that anchors on a segment and ranks by how much of the file is shared.** Anchoring closes `domain.go` standing in for `main.go`, `Foo.java` for `MyFoo.java`, and an entry with no name matching everything. The ranking fixes the tie-break, which `c7aca3b6` added with tests of absolute candidates that all end in the changed file, where the shortest is closest, and which was wrong for package paths the changed file ends in, where `com/example/Foo.java` shares more than `Foo.java` and yet always lost. A tie goes to the shorter candidate, and between candidates of equal length to the first listed, so every case in the existing table resolves as before.
- **A leading `./` is ignored on either side and nothing else is.** The first cut of this branch kept the old `strings.TrimLeft(x, "./")`, whose cutset also strips the dot of a dotfile, and the self-review measured that the anchor then lost `.eslintrc.js`, `.github/scripts/x.js` and `.storybook/preview.ts` in the un-normalized window this branch exists for, while widening `.config/x.go` onto `src/config/x.go`. The fixtures carry no leading-dot segment, which is why the self-lookup check missed it. Fixed in the second commit and pinned in the table.
- **With the matcher sound, the JaCoCo default package fix is safe to land.** `<package name="">` joined with a separator produced `/Foo.java`, which `filepath.IsAbs` calls absolute on Unix and the matcher then refused to read as a package path, so a changed path nested below the repository root never resolved to it unless `NormalizePaths` had rewritten it. The separator is now skipped when the package name is empty, and a `<sourcefile>` with no name makes no entry in any package. This supersedes #740, whose review found that landing the one-line change alone would have let the bare `Foo.java` outrank `com/example/Foo.java` under the old tie-break and let an empty key satisfy an `acceptable:` gate referencing `patch`.

The only widening beyond the fixes is that a package path written with a leading `./` now matches, since both sides are trimmed the same way where before only the absolute-path direction was. `coverage/patch.go` already carried a comment about two changed paths resolving to one entry and worked around it downstream for the patch total. The misattribution it did not work around is what the matcher change repairs, and the workaround stays, since a bare name in a report can still legitimately be the suffix of two changed paths.

All of this only bites when `NormalizePaths` cannot resolve the entries to repository paths, as outside a git checkout or for a report stored without `normalized_path`. Where normalization works, `EffectivePath` is the full path and every branch of the matcher degenerates to an exact match, so nothing changes.

Closes #729
