### PR TITLE
fix: count a Clover file from its lines and list it once

### DIFF
--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -154,10 +154,11 @@ func (c *Clover) ParseReport(path string) (*Coverage, string, error) {
 	}
 	for _, fcov := range cov.Files {
 		// Fold per line the way Coverage.reCalc does rather than trusting the <metrics>
-		// attributes. The report's own statement count is the more authoritative number in
-		// principle, but every path that shows a number already recounts from the blocks, so a
-		// total taken from <metrics> was one no consumer saw, and it could disagree with the
-		// blocks returned beside it, which no other LOC parser allows.
+		// attributes, so the total ParseReport returns agrees with the blocks returned beside
+		// it, the contract #728 and #734 settled for the other LOC parsers and #738 records.
+		// The report's own statement count is the more authoritative number in principle, but
+		// every path that shows a number recounts from the blocks, so a total taken from
+		// <metrics> was one no consumer saw.
 		lcs := fcov.Blocks.ToLineCoverages()
 		fcov.Total = lcs.Total()
 		fcov.Covered = lcs.Covered()

--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -182,12 +182,13 @@ func cloverIdentity(f CloverReportFile) (string, bool) {
 // isAbsReportPath reports whether a path a report recorded is absolute on the host that produced
 // the report. filepath.IsAbs answers for the host octocov runs on, so a Unix path read on Windows,
 // or a Windows path read on Unix, came out relative there, and a file was filed under the wrong
-// identity or refused a merge depending on the runner rather than on the report.
+// identity or refused a merge depending on the runner rather than on the report. It is not
+// consulted at all, since its Windows answer has also widened between Go releases.
 func isAbsReportPath(p string) bool {
-	if filepath.IsAbs(p) || strings.HasPrefix(p, "/") {
+	if strings.HasPrefix(p, "/") {
 		return true
 	}
-	// A drive letter and a separator, the volume shape filepath recognizes on Windows only.
+	// A drive letter and a separator, the one shape of a Windows absolute path a report writes.
 	return len(p) >= 3 && p[1] == ':' && (p[2] == '\\' || p[2] == '/') &&
 		(('a' <= p[0] && p[0] <= 'z') || ('A' <= p[0] && p[0] <= 'Z'))
 }

--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -119,12 +119,36 @@ func (c *Clover) ParseReport(path string) (*Coverage, string, error) {
 	// > Therefore, Clover offers a Statement Coverage metric, which is similar to a Line Coverage metric in terms of it's granularity and precision.
 	cov.Type = TypeLOC
 	cov.Format = c.Name()
+	// A file can be described at the project level and again inside a <package>, so elements
+	// naming the same file stack onto one entry rather than being listed and counted twice, the
+	// shape #724 described for LCOV. The lookup goes through a map rather than Files.FindByFile
+	// for the reason cobertura.go and jacoco.go record, that FindByFile rescans the slice once
+	// per element, and a Clover report has one <file> element per file, so a large report
+	// parsed in quadratic time. The map holds only identities that are unique by construction,
+	// a path attribute or an absolute name. A bare relative name is a display name two files can
+	// share, and stacking on it fused different files, so such an element is appended as before.
+	byIdentity := map[string]*FileCoverage{}
+	add := func(f CloverReportFile) {
+		identity, unique := cloverIdentity(f)
+		if unique {
+			if existing, ok := byIdentity[identity]; ok {
+				existing.Blocks = append(existing.Blocks, parseReportLines(f)...)
+				return
+			}
+		}
+		fcov := NewFileCoverage(identity, TypeLOC)
+		fcov.Blocks = parseReportLines(f)
+		cov.Files = append(cov.Files, fcov)
+		if unique {
+			byIdentity[identity] = fcov
+		}
+	}
 	for _, f := range r.Project.File {
-		cov.Files = append(cov.Files, parseReportFile(f))
+		add(f)
 	}
 	for _, p := range r.Project.Package {
 		for _, f := range p.File {
-			cov.Files = append(cov.Files, parseReportFile(f))
+			add(f)
 		}
 	}
 	for _, fcov := range cov.Files {
@@ -142,12 +166,19 @@ func (c *Clover) ParseReport(path string) (*Coverage, string, error) {
 	return cov, rp, nil
 }
 
-func parseReportFile(f CloverReportFile) *FileCoverage {
-	identity := f.Name
+// cloverIdentity returns the path an element is filed under and whether that path is unique by
+// construction. The path attribute is the real location and name the display name, typically a
+// basename (#639), so path wins when it is given and name is relative. An absolute name is a
+// real location too. A bare relative name is not, since files in different directories share it.
+func cloverIdentity(f CloverReportFile) (string, bool) {
 	if f.Path != "" && !filepath.IsAbs(f.Name) {
-		identity = f.Path
+		return f.Path, true
 	}
-	fcov := NewFileCoverage(identity, TypeLOC)
+	return f.Name, filepath.IsAbs(f.Name)
+}
+
+func parseReportLines(f CloverReportFile) BlockCoverages {
+	blocks := BlockCoverages{}
 	for _, l := range f.Line {
 		if l.Type != "stmt" {
 			continue
@@ -155,14 +186,14 @@ func parseReportFile(f CloverReportFile) *FileCoverage {
 		sl := l.Num
 		el := l.Num
 		c := toExecCount(l.Count)
-		fcov.Blocks = append(fcov.Blocks, &BlockCoverage{
+		blocks = append(blocks, &BlockCoverage{
 			Type:      TypeLOC,
 			StartLine: &sl,
 			EndLine:   &el,
 			Count:     &c,
 		})
 	}
-	return fcov
+	return blocks
 }
 
 func (c *Clover) detectReportPath(path string) (string, error) {

--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var _ Processor = (*Clover)(nil)
@@ -171,10 +172,23 @@ func (c *Clover) ParseReport(path string) (*Coverage, string, error) {
 // basename (#639), so path wins when it is given and name is relative. An absolute name is a
 // real location too. A bare relative name is not, since files in different directories share it.
 func cloverIdentity(f CloverReportFile) (string, bool) {
-	if f.Path != "" && !filepath.IsAbs(f.Name) {
+	if f.Path != "" && !isAbsReportPath(f.Name) {
 		return f.Path, true
 	}
-	return f.Name, filepath.IsAbs(f.Name)
+	return f.Name, isAbsReportPath(f.Name)
+}
+
+// isAbsReportPath reports whether a path a report recorded is absolute on the host that produced
+// the report. filepath.IsAbs answers for the host octocov runs on, so a Unix path read on Windows,
+// or a Windows path read on Unix, came out relative there, and a file was filed under the wrong
+// identity or refused a merge depending on the runner rather than on the report.
+func isAbsReportPath(p string) bool {
+	if filepath.IsAbs(p) || strings.HasPrefix(p, "/") {
+		return true
+	}
+	// A drive letter and a separator, the volume shape filepath recognizes on Windows only.
+	return len(p) >= 3 && p[1] == ':' && (p[2] == '\\' || p[2] == '/') &&
+		(('a' <= p[0] && p[0] <= 'z') || ('A' <= p[0] && p[0] <= 'Z'))
 }
 
 func parseReportLines(f CloverReportFile) BlockCoverages {

--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -120,18 +120,24 @@ func (c *Clover) ParseReport(path string) (*Coverage, string, error) {
 	cov.Type = TypeLOC
 	cov.Format = c.Name()
 	for _, f := range r.Project.File {
-		fcov := parseReportFile(f)
-		cov.Total += fcov.Total
-		cov.Covered += fcov.Covered
-		cov.Files = append(cov.Files, fcov)
+		cov.Files = append(cov.Files, parseReportFile(f))
 	}
 	for _, p := range r.Project.Package {
 		for _, f := range p.File {
-			fcov := parseReportFile(f)
-			cov.Total += fcov.Total
-			cov.Covered += fcov.Covered
-			cov.Files = append(cov.Files, fcov)
+			cov.Files = append(cov.Files, parseReportFile(f))
 		}
+	}
+	for _, fcov := range cov.Files {
+		// Fold per line the way Coverage.reCalc does rather than trusting the <metrics>
+		// attributes. The report's own statement count is the more authoritative number in
+		// principle, but every path that shows a number already recounts from the blocks, so a
+		// total taken from <metrics> was one no consumer saw, and it could disagree with the
+		// blocks returned beside it, which no other LOC parser allows.
+		lcs := fcov.Blocks.ToLineCoverages()
+		fcov.Total = lcs.Total()
+		fcov.Covered = lcs.Covered()
+		cov.Total += fcov.Total
+		cov.Covered += fcov.Covered
 	}
 	return cov, rp, nil
 }
@@ -142,8 +148,6 @@ func parseReportFile(f CloverReportFile) *FileCoverage {
 		identity = f.Path
 	}
 	fcov := NewFileCoverage(identity, TypeLOC)
-	fcov.Covered = f.Metrics.Coveredstatements
-	fcov.Total = f.Metrics.Statements
 	for _, l := range f.Line {
 		if l.Type != "stmt" {
 			continue

--- a/coverage/clover_test.go
+++ b/coverage/clover_test.go
@@ -247,8 +247,8 @@ func TestCloverMergesAbsoluteNameWithoutPath(t *testing.T) {
 func TestCloverKeepsSameNamedFilesWithoutPathApart(t *testing.T) {
 	// Files in different packages can share a bare name, and without a path attribute that name
 	// is all the report gives, so it cannot say whether two such elements are one file or two.
-	// They stay two entries rather than being fused into one whose lines would hide each other's
-	// misses. The report below has two files of two lines, one fully covered and one not at all.
+	// They stay two entries. The report below has two files of two lines, one fully covered and
+	// one not at all.
 	got := parseCloverString(t, `<?xml version="1.0" ?>
 <coverage generated="1">
   <project timestamp="1">

--- a/coverage/clover_test.go
+++ b/coverage/clover_test.go
@@ -1,6 +1,7 @@
 package coverage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -159,5 +160,117 @@ func TestCloverCountsFromLines(t *testing.T) {
 	}
 	if got.Total != 11 || got.Covered != 11 {
 		t.Errorf("got %d/%d\nwant 11/11", got.Total, got.Covered)
+	}
+}
+
+func parseCloverString(t *testing.T, content string) *Coverage {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "coverage.xml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := NewClover().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func TestCloverMergesFileNamedTwice(t *testing.T) {
+	// A report can describe one file at the project level and again inside a <package>. When
+	// both elements carry the path attribute the file is listed once, with the blocks of both
+	// stacked and counted once per line. The report below describes one file whose single
+	// listed line was executed.
+	got := parseCloverString(t, `<?xml version="1.0" ?>
+<coverage generated="1">
+  <project timestamp="1">
+    <file name="a.php" path="/src/a.php">
+      <metrics statements="5" coveredstatements="4"/>
+      <line num="1" type="stmt" count="1"/>
+    </file>
+    <package name="pkg">
+      <file name="a.php" path="/src/a.php">
+        <metrics statements="5" coveredstatements="4"/>
+        <line num="1" type="stmt" count="1"/>
+      </file>
+    </package>
+  </project>
+</coverage>
+`)
+	if want := 1; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if want := "/src/a.php"; got.Files[0].File != want {
+		t.Errorf("got %v\nwant %v", got.Files[0].File, want)
+	}
+	if got.Total != 1 || got.Covered != 1 {
+		t.Errorf("got %d/%d\nwant 1/1", got.Total, got.Covered)
+	}
+	// The blocks keep every listed line, so the totals came from folding them rather than
+	// from an append that dropped the repeat.
+	if want := 2; len(got.Files[0].Blocks) != want {
+		t.Errorf("got %v\nwant %v", len(got.Files[0].Blocks), want)
+	}
+	if err := got.Exclude(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got.Total != 1 || got.Covered != 1 {
+		t.Errorf("after Exclude got %d/%d\nwant 1/1", got.Total, got.Covered)
+	}
+}
+
+func TestCloverMergesAbsoluteNameWithoutPath(t *testing.T) {
+	// An absolute name is a real location on its own, so two elements naming it merge without a
+	// path attribute, which is how PHPUnit writes its reports.
+	got := parseCloverString(t, `<?xml version="1.0" ?>
+<coverage generated="1">
+  <project timestamp="1">
+    <file name="/src/a.php">
+      <line num="1" type="stmt" count="1"/>
+    </file>
+    <package name="pkg">
+      <file name="/src/a.php">
+        <line num="2" type="stmt" count="0"/>
+      </file>
+    </package>
+  </project>
+</coverage>
+`)
+	if want := 1; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if got.Total != 2 || got.Covered != 1 {
+		t.Errorf("got %d/%d\nwant 2/1", got.Total, got.Covered)
+	}
+}
+
+func TestCloverKeepsSameNamedFilesWithoutPathApart(t *testing.T) {
+	// Files in different packages can share a bare name, and without a path attribute that name
+	// is all the report gives, so it cannot say whether two such elements are one file or two.
+	// They stay two entries rather than being fused into one whose lines would hide each other's
+	// misses. The report below has two files of two lines, one fully covered and one not at all.
+	got := parseCloverString(t, `<?xml version="1.0" ?>
+<coverage generated="1">
+  <project timestamp="1">
+    <package name="src/a">
+      <file name="utils.ts">
+        <line num="1" type="stmt" count="1"/>
+        <line num="2" type="stmt" count="1"/>
+      </file>
+    </package>
+    <package name="src/b">
+      <file name="utils.ts">
+        <line num="1" type="stmt" count="0"/>
+        <line num="2" type="stmt" count="0"/>
+      </file>
+    </package>
+  </project>
+</coverage>
+`)
+	if want := 2; len(got.Files) != want {
+		t.Fatalf("got %v\nwant %v", len(got.Files), want)
+	}
+	if got.Total != 4 || got.Covered != 2 {
+		t.Errorf("got %d/%d\nwant 4/2", got.Total, got.Covered)
 	}
 }

--- a/coverage/clover_test.go
+++ b/coverage/clover_test.go
@@ -274,3 +274,28 @@ func TestCloverKeepsSameNamedFilesWithoutPathApart(t *testing.T) {
 		t.Errorf("got %d/%d\nwant 4/2", got.Total, got.Covered)
 	}
 }
+
+func TestIsAbsReportPath(t *testing.T) {
+	// The answer must not depend on the host octocov runs on, since the path describes the host
+	// that produced the report.
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/src/a.php", true},
+		{`C:\src\a.php`, true},
+		{"c:/src/a.php", true},
+		{"src/a.php", false},
+		{"a.php", false},
+		{"./a.php", false},
+		{"", false},
+		{"C:", false},
+		{`:\a.php`, false},
+		{`1:\a.php`, false},
+	}
+	for _, tt := range tests {
+		if got := isAbsReportPath(tt.path); got != tt.want {
+			t.Errorf("%q: got %v\nwant %v", tt.path, got, tt.want)
+		}
+	}
+}

--- a/coverage/clover_test.go
+++ b/coverage/clover_test.go
@@ -117,3 +117,47 @@ func TestCloverParseAllFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestCloverCountsFromLines(t *testing.T) {
+	// The totals come from the <line type="stmt"> elements, folded per line, and not from the
+	// <metrics> attributes, so what ParseReport returns is what its blocks support and what
+	// Exclude recounts to. The fixture declares statements="36" coveredstatements="28" for a
+	// file listing ten executed statement lines, and statements="0" for one listing a single
+	// executed line.
+	path := filepath.Join(testdataDir(t), "clover", "coverage_package.xml")
+	got, _, err := NewClover().ParseReport(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		file    string
+		total   int
+		covered int
+	}{
+		{"/path/to/src/Framework/Exception.php", 0, 0},
+		{"/path/to/src/Framework/Assert.php", 10, 10},
+		{"/path/to/src/app/libs/Util.php", 1, 1},
+	}
+	for _, tt := range tests {
+		f, err := got.Files.FindByFile(tt.file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if f.Total != tt.total || f.Covered != tt.covered {
+			t.Errorf("%s: got %d/%d\nwant %d/%d", tt.file, f.Total, f.Covered, tt.total, tt.covered)
+		}
+	}
+	if want := 11; got.Total != want {
+		t.Errorf("got %v\nwant %v", got.Total, want)
+	}
+	if want := 11; got.Covered != want {
+		t.Errorf("got %v\nwant %v", got.Covered, want)
+	}
+	// Exclude() recalculates from blocks; the totals must not change.
+	if err := got.Exclude(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got.Total != 11 || got.Covered != 11 {
+		t.Errorf("got %d/%d\nwant 11/11", got.Total, got.Covered)
+	}
+}


### PR DESCRIPTION
## Summary

- **`ParseReport` returned totals its own blocks did not support.** `parseReportFile` took `Total` and `Covered` from the `<metrics>` attributes while it built `Blocks` from the `<line type="stmt">` elements. On the checked-in `coverage_package.xml` that is 36/28 returned for a report whose blocks fold to 11/11. Clover was the last LOC parser to carry the defect #728 and #734 fixed elsewhere.
- **The totals now come from the lines, folded the way `reCalc` folds them, so the total agrees with the blocks beside it.** That is the contract #728 and #734 settled for the other four LOC parsers and #738 records. #733 left this half open because the `<metrics>` count is in principle the more authoritative number, and the body concedes that. What makes the change safe to make is that no consumer ever saw that number, since every command path reaches `reCalc`, which recounts from the blocks. Rendered numbers do not move. `coverage_package.xml` changes only at parse time, from 36/28 to the 11/11 that `Exclude` already produced, and `coverage.xml` at 11707/9430 and `coverage_path.xml` at 30/20 are unchanged at both stages. With both `current` and `patch` now derived from the same blocks, the divergence #742's review measured between them cannot arise.
- **A file described at both the project level and inside a `<package>` was listed and counted twice.** Elements now stack onto one entry, but only when the identity is unique by construction, a `path` attribute or an absolute `name`. A bare relative `name` is a display name two files can share, and #742's review measured that merging on it fused two files into one that read 100.0 percent for a pair that was 50.0. Those elements are appended as before. Two visible entries for what might be one file is the loud failure, one entry for what are two files the quiet one.
- **The lookup is a map, not `Files.FindByFile`.** `cobertura.go` and `jacoco.go` record why, that `FindByFile` rescans the slice once per element, and #742's draft, which used it, parsed 80000 files in 117 seconds against 0.3 on `main`. Against `main` this branch parses 10000 files in 58ms against 47ms and 60000 in 323ms against 257ms, linear in both. Order of first appearance is kept by appending on a miss.
- **Absoluteness is judged by the host that wrote the report, not the one running octocov.** The Windows CI job caught this. `filepath.IsAbs("/src/a.php")` is false there, so two elements naming that file were refused a merge and `TestCloverMergesAbsoluteNameWithoutPath` saw two entries. The identity rule inherited from #639 had the same dependence. A leading slash or a drive letter with a separator now both count, so identity and merge come out the same on every runner.

Clover now folds in the parser and again in `reCalc`, like the other four, so it joins the set #738 describes. Noted there.

The commits carry the decisions separately, since either could be reverted alone. This supersedes #742, whose review found the fusion, the quadratic parse, an allocation per element from using an error as an existence test, and a comment that described `Coverage.Merge` as keeping an earlier reading when it recomputes from the blocks.

Closes #733
