### PR TITLE
fix: skip a statement block whose count or statement number is omitted

### DIFF
--- a/coverage/merge.go
+++ b/coverage/merge.go
@@ -52,6 +52,12 @@ func (c *Coverage) reCalc() error {
 
 		case TypeStmt: // Coverage of a single unmerged TypeStmt.
 			for _, b := range f.Blocks {
+				// Both fields are omitempty, so a stored report can leave either out. Skip such a
+				// block so it contributes no statements, the same choice the line walks make for a
+				// block they cannot dereference, rather than rejecting the report at load time.
+				if b.NumStmt == nil || b.Count == nil {
+					continue
+				}
 				fileTotal += *b.NumStmt
 				if *b.Count > 0 {
 					fileCovered += *b.NumStmt

--- a/coverage/merge_test.go
+++ b/coverage/merge_test.go
@@ -752,3 +752,37 @@ func TestMerge(t *testing.T) {
 		})
 	}
 }
+
+func TestReCalcSkipsStatementBlockWithoutCountOrNumStmt(t *testing.T) {
+	// A statement block's count and statement number are both omitempty, so a stored report
+	// can come back without either. Recalculating from such a block must count nothing for it
+	// instead of dereferencing nil, and the complete block beside it must still be counted.
+	complete := newBlockCoverage(TypeStmt, 3, 1, 3, 5, 2, 1)
+	tests := []struct {
+		name  string
+		block *BlockCoverage
+	}{
+		{"no count", &BlockCoverage{Type: TypeStmt, StartLine: new(1), StartCol: new(1), EndLine: new(1), EndCol: new(5), NumStmt: new(1)}},
+		{"no num_stmt", &BlockCoverage{Type: TypeStmt, StartLine: new(1), StartCol: new(1), EndLine: new(1), EndCol: new(5), Count: new(ExecCount(1))}},
+		{"neither", &BlockCoverage{Type: TypeStmt}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Coverage{
+				Type: TypeStmt,
+				Files: FileCoverages{
+					&FileCoverage{File: "a.go", Type: TypeStmt, Blocks: BlockCoverages{tt.block, complete}},
+				},
+			}
+			if err := c.Exclude(nil); err != nil {
+				t.Fatal(err)
+			}
+			if want := 2; c.Total != want {
+				t.Errorf("got %v\nwant %v", c.Total, want)
+			}
+			if want := 2; c.Covered != want {
+				t.Errorf("got %v\nwant %v", c.Covered, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **A stored statement block with `count` or `num_stmt` omitted panicked `reCalc`.** The `TypeStmt` arm summed `*b.NumStmt` and read `*b.Count` for every block with no guard. Both fields are `omitempty`, so a report read back from a datastore can carry a block without either, and `MeasureCoverage` reaches `reCalc` through `Exclude` unconditionally. After #746 the same report degrades gracefully through `FindBlocksByLine`, `MaxCount` and `ToLineCoverages`, and still crashed the run through `reCalc` when the coverage is `type: statement`.
- **Such a block now contributes no statements, which is the choice #745 settled for the line walks.** The alternative was to have `Load` reject a statement block that lacks either field. #750 asks for the same answer as #745 for consistency, so the block is skipped where it is read and the complete blocks beside it are still counted.
- **The guard is its own check rather than a reuse of `walkable`.** `walkable` is the union of what the two line walks dereference, the range, the count and for a statement block the columns, and `reCalc`'s statement branch reads none of the range or the columns. Sharing it would have dropped a statement block with a full count and statement number over a missing column that this branch never touches. The reason sits on the guard, the way #746 put the `FindBlocksByLine` exception on its guard.

This closes the family #745 describes. #745 scoped itself to the two line walks and #744 mentions `reCalc` only for the wide-range case, so this was the remaining unguarded dereference of an `omitempty` block field.

Closes #750