### PR TITLE
perf: re-sum a folded file in reCalc instead of folding it again

### DIFF
--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -153,12 +153,12 @@ func (c *Clover) ParseReport(path string) (*Coverage, string, error) {
 		}
 	}
 	for _, fcov := range cov.Files {
-		// Fold per line the way Coverage.reCalc does rather than trusting the <metrics>
-		// attributes, so the total ParseReport returns agrees with the blocks returned beside
-		// it, the contract #728 and #734 settled for the other LOC parsers and #738 records.
-		// The report's own statement count is the more authoritative number in principle, but
-		// every path that shows a number recounts from the blocks, so a total taken from
-		// <metrics> was one no consumer saw.
+		// Fold per line through foldLines rather than trusting the <metrics> attributes, so the
+		// total ParseReport returns agrees with the blocks returned beside it, the contract #728
+		// and #734 settled for the other LOC parsers and #738 records. The report's own statement
+		// count is the more authoritative number in principle, but no consumer ever read it. Every
+		// path recounted from the blocks when #749 made this choice, and since #738 reCalc re-sums
+		// this fold instead, so the total folded here is the one every consumer sees.
 		fcov.foldLines()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered

--- a/coverage/clover.go
+++ b/coverage/clover.go
@@ -159,9 +159,7 @@ func (c *Clover) ParseReport(path string) (*Coverage, string, error) {
 		// The report's own statement count is the more authoritative number in principle, but
 		// every path that shows a number recounts from the blocks, so a total taken from
 		// <metrics> was one no consumer saw.
-		lcs := fcov.Blocks.ToLineCoverages()
-		fcov.Total = lcs.Total()
-		fcov.Covered = lcs.Covered()
+		fcov.foldLines()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered
 	}

--- a/coverage/clover_test.go
+++ b/coverage/clover_test.go
@@ -122,9 +122,9 @@ func TestCloverParseAllFormat(t *testing.T) {
 func TestCloverCountsFromLines(t *testing.T) {
 	// The totals come from the <line type="stmt"> elements, folded per line, and not from the
 	// <metrics> attributes, so what ParseReport returns is what its blocks support and what
-	// Exclude recounts to. The fixture declares statements="36" coveredstatements="28" for a
-	// file listing ten executed statement lines, and statements="0" for one listing a single
-	// executed line.
+	// Exclude carries through unchanged. The fixture declares statements="36"
+	// coveredstatements="28" for a file listing ten executed statement lines, and
+	// statements="0" for one listing a single executed line.
 	path := filepath.Join(testdataDir(t), "clover", "coverage_package.xml")
 	got, _, err := NewClover().ParseReport(path)
 	if err != nil {
@@ -154,7 +154,8 @@ func TestCloverCountsFromLines(t *testing.T) {
 	if want := 11; got.Covered != want {
 		t.Errorf("got %v\nwant %v", got.Covered, want)
 	}
-	// Exclude() recalculates from blocks; the totals must not change.
+	// Exclude() re-sums the totals the parser folded and refolds only when Blocks changed.
+	// The totals must not change.
 	if err := got.Exclude(nil); err != nil {
 		t.Fatal(err)
 	}

--- a/coverage/cobertura.go
+++ b/coverage/cobertura.go
@@ -136,9 +136,7 @@ func (c *Cobertura) ParseReport(path string) (*Coverage, string, error) {
 		// lambda shows up under its outer class and under a synthetic one), so fold the
 		// blocks per line the way Coverage.reCalc does. Counting one line per block would
 		// count such a line twice and return a total the blocks do not support.
-		lcs := blocks.ToLineCoverages()
-		fcov.Total = lcs.Total()
-		fcov.Covered = lcs.Covered()
+		fcov.foldLines()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered
 		cov.Files = append(cov.Files, fcov)

--- a/coverage/cobertura.go
+++ b/coverage/cobertura.go
@@ -134,8 +134,9 @@ func (c *Cobertura) ParseReport(path string) (*Coverage, string, error) {
 		fcov.Blocks = blocks
 		// Two <class> elements of one file can both list the same line (a Kotlin or Scala
 		// lambda shows up under its outer class and under a synthetic one), so fold the
-		// blocks per line the way Coverage.reCalc does. Counting one line per block would
-		// count such a line twice and return a total the blocks do not support.
+		// blocks per line through foldLines, whose result reCalc re-sums instead of recomputing.
+		// Counting one line per block would count such a line twice and return a total the
+		// blocks do not support.
 		fcov.foldLines()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -56,6 +56,11 @@ type FileCoverage struct {
 	Covered        int            `json:"covered"`
 	Blocks         BlockCoverages `json:"blocks,omitempty"`
 	cache          map[int]BlockCoverages
+	// foldedBlocks is len(Blocks) at the moment Total and Covered were last folded from them,
+	// or 0 when they never were, as in a report decoded from JSON. It is a count rather than a
+	// flag because Blocks is exported and can be appended to without going through any method,
+	// and a flag would keep reading as current while the totals were stale (#738).
+	foldedBlocks int
 }
 
 func NewFileCoverage(file string, coverageType Type) *FileCoverage { //nostyle:repetition
@@ -564,6 +569,15 @@ func (lc LineCoverages) Covered() int { //nostyle:recvtype
 		}
 	}
 	return covered
+}
+
+// foldLines folds Blocks per line into Total and Covered and records the block count it folded,
+// so reCalc can re-sum the file instead of folding it a second time while Blocks is unchanged.
+func (fc *FileCoverage) foldLines() {
+	lcs := fc.Blocks.ToLineCoverages()
+	fc.Total = lcs.Total()
+	fc.Covered = lcs.Covered()
+	fc.foldedBlocks = len(fc.Blocks)
 }
 
 func (bc BlockCoverages) ToLineCoverages() LineCoverages { //nostyle:recvtype

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -151,9 +151,7 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 		// A <sourcefile> lists each line once, but a repeated <package> name brings the same
 		// file back with lines that may repeat, so fold the blocks per line the way
 		// Coverage.reCalc does rather than counting one line per block.
-		lcs := blocks.ToLineCoverages()
-		fcov.Total = lcs.Total()
-		fcov.Covered = lcs.Covered()
+		fcov.foldLines()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered
 		cov.Files = append(cov.Files, fcov)

--- a/coverage/jacoco.go
+++ b/coverage/jacoco.go
@@ -149,8 +149,9 @@ func (c *Jacoco) ParseReport(path string) (*Coverage, string, error) {
 		fcov := NewFileCoverage(f, TypeLOC)
 		fcov.Blocks = blocks
 		// A <sourcefile> lists each line once, but a repeated <package> name brings the same
-		// file back with lines that may repeat, so fold the blocks per line the way
-		// Coverage.reCalc does rather than counting one line per block.
+		// file back with lines that may repeat, so fold the blocks per line through
+		// foldLines, whose result reCalc re-sums instead of recomputing, rather than counting one
+		// line per block.
 		fcov.foldLines()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered

--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -111,9 +111,7 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 	// than on every end_of_record keeps a file named by R records from being re-folded R
 	// times.
 	for _, fcov := range cov.Files {
-		lcs := fcov.Blocks.ToLineCoverages()
-		fcov.Total = lcs.Total()
-		fcov.Covered = lcs.Covered()
+		fcov.foldLines()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered
 	}

--- a/coverage/lcov.go
+++ b/coverage/lcov.go
@@ -106,8 +106,9 @@ func (l *Lcov) ParseReport(path string) (*Coverage, string, error) {
 	if !parsed {
 		return nil, "", errors.New("can not parse")
 	}
-	// Fold per line the way Coverage.reCalc does rather than counting one line per block,
-	// which would count a line twice when a record repeats it. Folding here once rather
+	// Fold per line through foldLines, whose result reCalc re-sums instead of recomputing,
+	// rather than counting one line per block, which would count a line twice when a record
+	// repeats it. Folding here once rather
 	// than on every end_of_record keeps a file named by R records from being re-folded R
 	// times.
 	for _, fcov := range cov.Files {

--- a/coverage/lcov_test.go
+++ b/coverage/lcov_test.go
@@ -204,7 +204,8 @@ end_of_record
 	if want := 3; got.Covered != want {
 		t.Errorf("got %v\nwant %v", got.Covered, want)
 	}
-	// Exclude() recalculates from blocks; the totals must not change.
+	// Exclude() re-sums the totals the parser folded and refolds only when Blocks changed.
+	// The totals must not change.
 	if err := got.Exclude(nil); err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +258,8 @@ end_of_record
 	if want := 2; got.Covered != want {
 		t.Errorf("got %v\nwant %v", got.Covered, want)
 	}
-	// Exclude() recalculates from blocks; the totals must not change.
+	// Exclude() re-sums the totals the parser folded and refolds only when Blocks changed.
+	// The totals must not change.
 	if err := got.Exclude(nil); err != nil {
 		t.Fatal(err)
 	}

--- a/coverage/merge.go
+++ b/coverage/merge.go
@@ -46,9 +46,18 @@ func (c *Coverage) reCalc() error {
 
 		switch c.Type {
 		case TypeLOC, TypeMerged:
-			lcs := f.Blocks.ToLineCoverages()
-			fileTotal = lcs.Total()
-			fileCovered = lcs.Covered()
+			// A file the parser folded from these very blocks is re-summed rather than re-folded, since
+			// the fold is deterministic over Blocks and would only reproduce Total and Covered (#738).
+			// Anything that changed the block count, a Merge stacking a second report or an append
+			// through the exported field, and any file never folded, such as one an older octocov
+			// stored with one line counted per block, is folded here as before. A block edited in
+			// place is not detected. Catching that would mean fingerprinting every block on every
+			// reCalc, and nothing in octocov edits a block after parsing.
+			if f.foldedBlocks == 0 || f.foldedBlocks != len(f.Blocks) {
+				f.foldLines()
+			}
+			fileTotal = f.Total
+			fileCovered = f.Covered
 
 		case TypeStmt: // Coverage of a single unmerged TypeStmt.
 			for _, b := range f.Blocks {

--- a/coverage/merge_test.go
+++ b/coverage/merge_test.go
@@ -786,3 +786,55 @@ func TestReCalcSkipsStatementBlockWithoutCountOrNumStmt(t *testing.T) {
 		})
 	}
 }
+
+func TestReCalcRefoldsWhenBlocksChange(t *testing.T) {
+	// Blocks is exported, so a caller can append to it without going through Merge. Total and
+	// Covered folded before such an append are stale and must be folded again, while a file
+	// whose blocks are unchanged keeps the totals its parser folded.
+	fc := &FileCoverage{File: "a.rb", Type: TypeLOC, Blocks: BlockCoverages{
+		newBlockCoverage(TypeLOC, 1, -1, 1, -1, 1, 1),
+		newBlockCoverage(TypeLOC, 2, -1, 2, -1, 1, 0),
+	}}
+	fc.foldLines()
+	c := &Coverage{Type: TypeLOC, Files: FileCoverages{fc}}
+	if err := c.Exclude(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := [2]int{c.Total, c.Covered}, [2]int{2, 1}; got != want {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+
+	fc.Blocks = append(fc.Blocks, newBlockCoverage(TypeLOC, 2, -1, 3, -1, 1, 1))
+	if err := c.Exclude(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := [2]int{c.Total, c.Covered}, [2]int{3, 3}; got != want {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}
+
+func TestReCalcRepairsTotalsNeverFoldedFromBlocks(t *testing.T) {
+	// A report decoded from JSON carries whatever totals the octocov that stored it computed.
+	// One that counted a line per block over-counts a repeated line, so recalculating must
+	// fold the blocks rather than trust those totals.
+	c := &Coverage{
+		Type: TypeLOC,
+		Files: FileCoverages{
+			&FileCoverage{File: "a.rb", Type: TypeLOC, Total: 2, Covered: 2, Blocks: BlockCoverages{
+				newBlockCoverage(TypeLOC, 1, -1, 1, -1, 1, 1),
+				newBlockCoverage(TypeLOC, 1, -1, 1, -1, 1, 1),
+			}},
+		},
+		Total:   2,
+		Covered: 2,
+	}
+	if err := c.Exclude(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := [2]int{c.Total, c.Covered}, [2]int{1, 1}; got != want {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+	if got, want := [2]int{c.Files[0].Total, c.Files[0].Covered}, [2]int{1, 1}; got != want {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}

--- a/coverage/recalc_bench_test.go
+++ b/coverage/recalc_bench_test.go
@@ -1,0 +1,38 @@
+package coverage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// BenchmarkParseReportAndExclude measures the path report.MeasureCoverage takes for one LOC
+// report, ParseReport followed by Exclude with no patterns, on a generated LCOV tracefile.
+func BenchmarkParseReportAndExclude(b *testing.B) {
+	const files, lines = 2000, 200
+	var sb strings.Builder
+	for f := range files {
+		fmt.Fprintf(&sb, "SF:src/file%04d.ts\n", f)
+		for l := 1; l <= lines; l++ {
+			fmt.Fprintf(&sb, "DA:%d,%d\n", l, l%3)
+		}
+		sb.WriteString("end_of_record\n")
+	}
+	path := filepath.Join(b.TempDir(), "lcov.info")
+	if err := os.WriteFile(path, []byte(sb.String()), 0600); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		cov, _, err := NewLcov().ParseReport(path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := cov.Exclude(nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/coverage/simplecov.go
+++ b/coverage/simplecov.go
@@ -117,9 +117,7 @@ func (s *Simplecov) ParseReport(path string) (*Coverage, string, error) {
 			fcov.Blocks = append(fcov.Blocks, b)
 		}
 
-		lcs := fcov.Blocks.ToLineCoverages()
-		fcov.Total = lcs.Total()
-		fcov.Covered = lcs.Covered()
+		fcov.foldLines()
 		cov.Total += fcov.Total
 		cov.Covered += fcov.Covered
 	}


### PR DESCRIPTION
## Summary

- **Every LOC report was folded per line twice, and the second fold always reproduced the first.** `MeasureCoverage` ends in `Exclude`, `Exclude` ends in `reCalc`, and `reCalc` folded `f.Blocks.ToLineCoverages()` for every file the parser had just folded from the same blocks. SimpleCov, Cobertura (#731), JaCoCo, LCOV (#735) and Clover (#749) all fold in the parser now, so on the 2000 files by 200 lines report #738 measured, the path went from 500ms and 554MB allocated to 295ms and 314MB. Allocations fall from 14.5M to 8.5M.
- **The parser-side fold stays, the downstream one goes, and only when nothing has moved.** #728 and #734 settled that a total `ParseReport` returns has to agree with the blocks beside it, so the parser has to fold. `FileCoverage` now records how many blocks its totals were folded from, through `foldLines`, which the five LOC parsers call in place of their three-line copies of the fold. `reCalc` re-sums a file whose count still matches and folds any other as before.
- **The marker is a count rather than a flag, which is the answer to the exported-field question #738 raised.** `Blocks` is exported, so a consumer can append to it without calling anything. A boolean would have read as current while the totals were stale, the self-inconsistency #728 and #734 set out to remove. A count changes on any append, whether through `Merge` stacking a second report or through the field itself, so those files are folded. A block edited in place is the one shape not detected. Catching it would mean fingerprinting every block on every `reCalc`, and nothing in octocov edits a block after parsing. The comment on the guard says so.
- **Skipping `reCalc` when the exclude list is empty was the blunter option and is not what this does.** `reCalc` also repairs a report an older octocov stored with one line counted per block. A report decoded from JSON carries no marker, so it is folded exactly as before, and a test pins that a stored report over-counting a repeated line comes out at the folded total.

The benchmark reproduces the measurement #738 made by swapping `lcov.go` between two versions, which nobody could re-run without rebuilding. It generates the report in a temporary directory so testdata does not grow by 3.5MB.

Closes #738