### PR TITLE
feat: show the numbers behind each metric in the local table

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -247,8 +247,8 @@ func (r *Report) Out(w io.Writer) error {
 	if r.IsMeasuredCoverage() {
 		table.Rich([]string{"Coverage", fmt.Sprintf("%.1f%%", floor1(r.CoveragePercent()))}, []tablewriter.Colors{tablewriter.Colors{tablewriter.Bold}, tablewriter.Colors{}})
 		table.Append([]string{"  Files", fmt.Sprintf("%d", len(r.Coverage.Files))})
+		table.Append([]string{"  Lines", fmt.Sprintf("%d", r.Coverage.Total)})
 		table.Append([]string{"  Covered", fmt.Sprintf("%d", r.Coverage.Covered)})
-		table.Append([]string{"  Total", fmt.Sprintf("%d", r.Coverage.Total)})
 	}
 
 	if r.IsMeasuredCodeToTestRatio() {

--- a/report/report.go
+++ b/report/report.go
@@ -246,10 +246,15 @@ func (r *Report) Out(w io.Writer) error {
 
 	if r.IsMeasuredCoverage() {
 		table.Rich([]string{"Coverage", fmt.Sprintf("%.1f%%", floor1(r.CoveragePercent()))}, []tablewriter.Colors{tablewriter.Colors{tablewriter.Bold}, tablewriter.Colors{}})
+		table.Append([]string{"  Files", fmt.Sprintf("%d", len(r.Coverage.Files))})
+		table.Append([]string{"  Covered", fmt.Sprintf("%d", r.Coverage.Covered)})
+		table.Append([]string{"  Total", fmt.Sprintf("%d", r.Coverage.Total)})
 	}
 
 	if r.IsMeasuredCodeToTestRatio() {
 		table.Rich([]string{"Code to Test Ratio", fmt.Sprintf("1:%.1f", floor1(r.CodeToTestRatioRatio()))}, []tablewriter.Colors{tablewriter.Colors{tablewriter.Bold}, tablewriter.Colors{}})
+		table.Append([]string{"  Code", fmt.Sprintf("%d", r.CodeToTestRatio.Code)})
+		table.Append([]string{"  Test", fmt.Sprintf("%d", r.CodeToTestRatio.Test)})
 	}
 
 	if r.IsMeasuredTestExecutionTime() {

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -373,11 +373,11 @@ func TestOut(t *testing.T) {
 	}{
 		{
 			filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json"),
-			"             master (896d3c5)  \n-------------------------------\n  \x1b[1mCoverage\x1b[0m              68.4%  \n    Files                  31  \n    Covered              1957  \n    Total                2857  \n",
+			"             master (896d3c5)  \n-------------------------------\n  \x1b[1mCoverage\x1b[0m              68.4%  \n    Files                  31  \n    Lines                2857  \n    Covered              1957  \n",
 		},
 		{
 			filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json"),
-			"                       master (896d3c5)  \n-----------------------------------------\n  \x1b[1mCoverage\x1b[0m                        68.4%  \n    Files                            31  \n    Covered                        1957  \n    Total                          2857  \n  \x1b[1mCode to Test Ratio\x1b[0m              1:0.5  \n    Code                           7202  \n    Test                           3704  \n  \x1b[1mTest Execution Time\x1b[0m             4m40s  \n",
+			"                       master (896d3c5)  \n-----------------------------------------\n  \x1b[1mCoverage\x1b[0m                        68.4%  \n    Files                            31  \n    Lines                          2857  \n    Covered                        1957  \n  \x1b[1mCode to Test Ratio\x1b[0m              1:0.5  \n    Code                           7202  \n    Test                           3704  \n  \x1b[1mTest Execution Time\x1b[0m             4m40s  \n",
 		},
 	}
 	for _, tt := range tests {

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/k1LoW/octocov/coverage"
 	"github.com/k1LoW/octocov/gh"
 	"github.com/k1LoW/octocov/ratio"
+	"github.com/tenntenn/golden"
 	"golang.org/x/text/language"
 )
 
@@ -367,31 +368,26 @@ func TestTable(t *testing.T) {
 }
 
 func TestOut(t *testing.T) {
-	tests := []struct {
-		path string
-		want string
-	}{
-		{
-			filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json"),
-			"             master (896d3c5)  \n-------------------------------\n  \x1b[1mCoverage\x1b[0m              68.4%  \n    Files                  31  \n    Lines                2857  \n    Covered              1957  \n",
-		},
-		{
-			filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json"),
-			"                       master (896d3c5)  \n-----------------------------------------\n  \x1b[1mCoverage\x1b[0m                        68.4%  \n    Files                            31  \n    Lines                          2857  \n    Covered                        1957  \n  \x1b[1mCode to Test Ratio\x1b[0m              1:0.5  \n    Code                           7202  \n    Test                           3704  \n  \x1b[1mTest Execution Time\x1b[0m             4m40s  \n",
-		},
+	tests := []string{
+		filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json"),
+		filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json"),
 	}
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
+	for i, path := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			r := &Report{}
-			if err := r.Load(tt.path); err != nil {
+			if err := r.Load(path); err != nil {
 				t.Fatal(err)
 			}
-			buf := new(bytes.Buffer)
-			if err := r.Out(buf); err != nil {
+			got := new(bytes.Buffer)
+			if err := r.Out(got); err != nil {
 				t.Fatal(err)
 			}
-			got := buf.String()
-			if diff := cmp.Diff(got, tt.want, nil); diff != "" {
+			f := fmt.Sprintf("out.%d", i)
+			if os.Getenv("UPDATE_GOLDEN") != "" {
+				golden.Update(t, testdataDir(t), f, got)
+				return
+			}
+			if diff := golden.Diff(t, testdataDir(t), f, got); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -373,11 +373,11 @@ func TestOut(t *testing.T) {
 	}{
 		{
 			filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report.json"),
-			"            master (896d3c5)  \n------------------------------\n  \x1b[1mCoverage\x1b[0m             68.4%  \n",
+			"             master (896d3c5)  \n-------------------------------\n  \x1b[1mCoverage\x1b[0m              68.4%  \n    Files                  31  \n    Covered              1957  \n    Total                2857  \n",
 		},
 		{
 			filepath.Join(testdataDir(t), "reports", "k1LoW", "tbls", "report2.json"),
-			"                       master (896d3c5)  \n-----------------------------------------\n  \x1b[1mCoverage\x1b[0m                        68.4%  \n  \x1b[1mCode to Test Ratio\x1b[0m              1:0.5  \n  \x1b[1mTest Execution Time\x1b[0m             4m40s  \n",
+			"                       master (896d3c5)  \n-----------------------------------------\n  \x1b[1mCoverage\x1b[0m                        68.4%  \n    Files                            31  \n    Covered                        1957  \n    Total                          2857  \n  \x1b[1mCode to Test Ratio\x1b[0m              1:0.5  \n    Code                           7202  \n    Test                           3704  \n  \x1b[1mTest Execution Time\x1b[0m             4m40s  \n",
 		},
 	}
 	for _, tt := range tests {

--- a/testdata/out.0.golden
+++ b/testdata/out.0.golden
@@ -1,0 +1,6 @@
+             master (896d3c5)  
+-------------------------------
+  [1mCoverage[0m              68.4%  
+    Files                  31  
+    Lines                2857  
+    Covered              1957  

--- a/testdata/out.1.golden
+++ b/testdata/out.1.golden
@@ -1,0 +1,10 @@
+                       master (896d3c5)  
+-----------------------------------------
+  [1mCoverage[0m                        68.4%  
+    Files                            31  
+    Lines                          2857  
+    Covered                        1957  
+  [1mCode to Test Ratio[0m              1:0.5  
+    Code                           7202  
+    Test                           3704  
+  [1mTest Execution Time[0m             4m40s  


### PR DESCRIPTION
## Summary

- **The local table showed a percentage and a ratio, and no way to see what they were computed from.** `octocov` run without arguments prints Coverage and Code to Test Ratio as single values. The counts behind them are reachable only through `ls-files` and `view`, which answer per file. #374 asks for the totals, which nothing printed.

```
                      more-summary (588a2e6)
----------------------------------------------
  Coverage                              91.2%
    Files                                  12
    Lines                                 856
    Covered                               781
  Code to Test Ratio                    1:0.9
    Code                                 8679
    Test                                 8267
```

- **The labels, the order and the indent are the ones `octocov diff` has used since ab52ec0.** `DiffReport.Out` renders this same breakdown with `detail` fixed to true, so `testdata/diff_out.golden` already pins `Files` / `Lines` / `Covered` and `Code` / `Test`. Both tables reach the same terminal in the same run, and the first commit here got the coverage rows wrong before this was noticed, calling `Coverage.Total` `Total` and ordering the rows differently. Whether `Lines` is the right word for a statement-typed report is a question about both tables rather than this one.

- **The ratio breakdown goes in too, though #374 only asked about coverage.** Both metrics have counts behind a single derived number, `octocov diff` shows both, and showing one and not the other here would be arbitrary.

- **`TestOut` moves onto a golden file.** 90247de put every other terminal-output assertion in the package on `tenntenn/golden`, and this one was the last holdout. Its expectations were escaped one-line literals carrying ANSI codes and column padding, so the new rows meant hand-widening a header rule by a character to keep the test passing. The two cases are now `testdata/out.0.golden` and `testdata/out.1.golden`, regenerable with `UPDATE_GOLDEN`.

`Out` is also what the Actions run prints to the job log, so the breakdown appears there as well. The PR comment and the job summary go through `Table`, which stays one row per metric, matching the `detail=false` side of `DiffReport.renderTable`.

Closes #374